### PR TITLE
[2.x] Current connected account context

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Laravel\Jetstream\Features;
 
 class CreateUsersTable extends Migration
 {

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -22,6 +22,7 @@ class CreateUsersTable extends Migration
             $table->string('password')->nullable();
             $table->rememberToken();
             $table->foreignId('current_team_id')->nullable();
+            $table->foreignId('current_connected_account_id')->nullable();
             $table->text('profile_photo_path')->nullable();
             $table->timestamps();
         });

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -80,6 +80,8 @@ class InstallCommand extends Command
         // Directories...
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Jetstream'));
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Socialstream'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/app/Actions/Socialstream', app_path('Actions/Socialstream'));
+
         (new Filesystem)->ensureDirectoryExists(resource_path('views/auth'));
         (new Filesystem)->ensureDirectoryExists(resource_path('views/profile'));
         (new Filesystem)->ensureDirectoryExists(resource_path('views/components'));
@@ -97,11 +99,6 @@ class InstallCommand extends Command
         // Jetstream Actions...
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUser.php', app_path('Actions/Jetstream/DeleteUser.php'));
 
-        // Actions...
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/CreateUserFromProvider.php', app_path('Actions/Socialstream/CreateUserFromProvider.php'));
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/SetUserPassword.php', app_path('Actions/Socialstream/SetUserPassword.php'));
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/HandleInvalidState.php', app_path('Actions/Socialstream/HandleInvalidState.php'));
-        
         // Auth views...
         copy(__DIR__.'/../../stubs/resources/views/auth/login.blade.php', resource_path('views/auth/login.blade.php'));
         copy(__DIR__.'/../../stubs/resources/views/auth/register.blade.php', resource_path('views/auth/register.blade.php'));
@@ -128,6 +125,8 @@ class InstallCommand extends Command
         // Directories...
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Jetstream'));
         (new Filesystem)->ensureDirectoryExists(app_path('Actions/Socialstream'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/app/Actions/Socialstream', app_path('Actions/Socialstream'));
+        
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Socialstream'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/ProviderIcons'));
         (new Filesystem)->ensureDirectoryExists(resource_path('js/Pages/Profile'));
@@ -149,11 +148,6 @@ class InstallCommand extends Command
 
         // Jetstream Actions...
         copy(__DIR__.'/../../stubs/app/Actions/Jetstream/DeleteUser.php', app_path('Actions/Jetstream/DeleteUser.php'));
-
-        // Actions...
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/CreateUserFromProvider.php', app_path('Actions/Socialstream/CreateUserFromProvider.php'));
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/SetUserPassword.php', app_path('Actions/Socialstream/SetUserPassword.php'));
-        copy(__DIR__.'/../../stubs/app/Actions/Socialstream/HandleInvalidState.php', app_path('Actions/Socialstream/HandleInvalidState.php'));
 
         // Auth views...
         copy(__DIR__.'/../../stubs/resources/views/auth/login.blade.php', resource_path('views/auth/login.blade.php'));

--- a/src/Contracts/CreatesConnectedAccounts.php
+++ b/src/Contracts/CreatesConnectedAccounts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace JoelButcher\Socialstream\Contracts;
+
+use App\Models\User;
+use Laravel\Socialite\Contracts\User as ProviderUser;
+
+interface CreatesConnectedAccounts
+{
+    /**
+     * Create a connected account for a given user.
+     * 
+     * @param  \App\Models\User  $user
+     * @param  string  $provider
+     * @param  \Laravel\Socialite\Contracts\User  $providerUser
+     * @return \JoelButcher\Socialstream\ConnectedAccount
+     */
+    public function create(User $user, string $provider, ProviderUser $providerUser);
+}

--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -7,6 +7,61 @@ use Illuminate\Support\Str;
 trait HasConnectedAccounts
 {
     /**
+     * Determine if the given connected account is the current connected account.
+     *
+     * @param  mixed  $connectedAccount
+     * @return bool
+     */
+    public function isCurrentConnectedAccount($connectedAccount)
+    {
+        return $connectedAccount->id === $this->currentConnectedAccount->id;
+    }
+
+    /**
+     * Get the current connected account of the user's context.
+     */
+    public function currentConnectedAccount()
+    {
+        if (is_null($this->current_connected_account_id) && $this->id) {
+            $this->switchConnectedAccount($this->personalTeam());
+        }
+
+        return $this->belongsTo(Socialstream::connectedAccountModel(), 'current_connected_account_id');
+    }
+
+    /**
+     * Switch the user's context to the given connected account.
+     *
+     * @param  mixed  $connectedAccount
+     * @return bool
+     */
+    public function switchConnectedAccount($connectedAccount)
+    {
+        if ($this->ownsConnectedAccount($connectedAccount)) {
+            return false;
+        }
+
+        $this->forceFill([
+            'current_connected_account_id' => $connectedAccount->id,
+        ])->save();
+
+        $this->setRelation('currentConnectedAccount', $connectedAccount);
+
+        return true;
+    }
+
+    /**
+     * Determine if the user owns the given connected account.
+     *
+     * @param  mixed  $connectedAccount
+     * @return bool
+     */
+    public function ownsConnectedAccount($connectedAccount)
+    {
+        return $this->id == $connectedAccount->user_id;
+    }
+
+    /**
      * Determine if the user has a specific account type.
      *
      * @param  string  $accountType

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -128,7 +128,11 @@ class OAuthController extends Controller
                 $providerAccount
             );
 
-            $this->guard->login($account->user);
+            $this->guard->login($user);
+
+            $user->forceFill([
+                'current_connected_account_id' => $account->id,
+            ]);
 
             return redirect(config('fortify.home'));
         }
@@ -140,6 +144,10 @@ class OAuthController extends Controller
         }
 
         $this->guard->login($account->user);
+
+        $account->user->forceFill([
+            'current_connected_account_id' => $account->id,
+        ]);
 
         return redirect(config('fortify.home'));
     }

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -10,7 +10,6 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
-use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -51,8 +50,12 @@ class OAuthController extends Controller
      * @param  \Illuminate\Contracts\Auth\StatefulGuard  $guard
      * @return void
      */
-    public function __construct(StatefulGuard $guard, CreatesUserFromProvider $createsUser, CreatesConnectedAccounts $createsConnectedAccounts, HandleInvalidState $invalidStateHandler)
-    {
+    public function __construct(
+        StatefulGuard $guard,
+        CreatesUserFromProvider $createsUser,
+        CreatesConnectedAccounts $createsConnectedAccounts,
+        HandleInvalidState $invalidStateHandler
+    ) {
         $this->guard = $guard;
         $this->createsUser = $createsUser;
         $this->createsConnectedAccounts = $createsConnectedAccounts;

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -2,6 +2,7 @@
 
 namespace JoelButcher\Socialstream;
 
+use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use JoelButcher\Socialstream\Contracts\SetsUserPasswords;
@@ -96,6 +97,17 @@ class Socialstream
     public static function createUsersFromProviderUsing(string $class)
     {
         return app()->singleton(CreatesUserFromProvider::class, $class);
+    }
+
+    /**
+     * Register a class / callback that should be used to create connected accounts
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public static function createConnectedAccountsUsing(string $class)
+    {
+        return app()->singleton(CreatesConnectedAccounts::class, $class);
     }
 
     /**

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace JoelButcher\Socialstream\Actions;
+
+use App\Models\User;
+use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
+use Laravel\Socialite\Contracts\User as ProviderUser;
+
+class CreateConnectedAccount implements CreatesConnectedAccounts
+{
+    /**
+     * Create a connected account for a given user.
+     * 
+     * @param  \App\Models\User  $user
+     * @param  string  $provider
+     * @param  \Laravel\Socialite\Contracts\User  $providerUser
+     * @return \JoelButcher\Socialstream\ConnectedAccount
+     */
+    public function create(User $user, string $provider, ProviderUser $providerUser)
+    {
+        if ($user->hasTokenFor($provider)) {
+            $connectedAccount = $user->getTokenFor($provider);
+            
+            $connectedAccount->forceFill([
+                'provider_name' => strtolower($provider),
+                'provider_id' => $providerUser->getId(),
+                'token' => $providerUser->token,
+                'secret' => $providerUser->tokenSecret ?? null,
+                'refresh_token' => $providerUser->refreshToken ?? null,
+                'expires_at' => $providerUser->expiresAt ?? null,
+            ])->save();
+
+            return $connectedAccount;
+        }
+
+        return $user->connectedAccounts()->create([
+            'provider_name' => strtolower($provider),
+            'provider_id' => $providerUser->getId(),
+            'token' => $providerUser->token,
+            'secret' => $providerUser->tokenSecret ?? null,
+            'refresh_token' => $providerUser->refreshToken ?? null,
+            'expires_at' => $providerUser->expiresAt ?? null,
+        ]);
+    }
+}

--- a/stubs/app/Providers/SocialstreamServiceProvider.php
+++ b/stubs/app/Providers/SocialstreamServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Actions\Socialstream\CreateConnectedAccount;
 use App\Actions\Socialstream\CreateUserFromProvider;
 use App\Actions\Socialstream\HandleInvalidState;
 use App\Actions\Socialstream\SetUserPassword;
@@ -28,6 +29,7 @@ class SocialstreamServiceProvider extends ServiceProvider
     public function boot()
     {
         Socialstream::createUsersFromProviderUsing(CreateUserFromProvider::class);
+        Socialstream::createConnectedAccountsUsing(CreateConnectedAccount::class);
         Socialstream::setUserPasswordsUsing(SetUserPassword::class);
         Socialstream::handlesInvalidStateUsing(HandleInvalidState::class);
     }

--- a/tests/CreateUserFromProviderTest.php
+++ b/tests/CreateUserFromProviderTest.php
@@ -24,6 +24,7 @@ class CreateUserFromProviderTest extends TestCase
         $user = $action->create('github', $providerUser);
 
         $this->assertEquals($providerUser->email, $user->email);
+        $this->assertCount(1, $user->connectedAccounts);
     }
 
     public function test_user_can_be_created_from_o_auth_2_provider()
@@ -41,6 +42,7 @@ class CreateUserFromProviderTest extends TestCase
         $user = $action->create('github', $providerUser);
 
         $this->assertEquals($providerUser->email, $user->email);
+        $this->assertCount(1, $user->connectedAccounts);
     }
 
     protected function migrate()


### PR DESCRIPTION
This PR adds a new `current_connected_account_id` column to the users table. The value of this column is populated on registration & login with the id of the connected account used to start that session. 

A possible resolution to #9 