### PR TITLE
[1.x] fix CORS error by using anchor instead of inertia-link

### DIFF
--- a/stubs/inertia/resources/js/Socialstream/ActionLink.vue
+++ b/stubs/inertia/resources/js/Socialstream/ActionLink.vue
@@ -1,7 +1,7 @@
 <template>
-    <inertia-link :href="href" class="inline-flex items-center px-4 py-2 bg-white border border-gray-800 rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-200 hover:border-gray-600 active:border-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150">
+    <a :href="href" class="inline-flex items-center px-4 py-2 bg-white border border-gray-800 rounded-md font-semibold text-xs text-gray-800 uppercase tracking-widest hover:bg-gray-200 hover:border-gray-600 active:border-gray-900 focus:outline-none focus:border-gray-900 focus:shadow-outline-gray disabled:opacity-25 transition ease-in-out duration-150">
         <slot></slot>
-    </inertia-link>
+    </a>
 </template>
 
 <script>
@@ -9,4 +9,3 @@
         props: ['href'],
     }
 </script>
-``


### PR DESCRIPTION
The oauth provider ignores your oauth request with missing cors allowance. So you have to do a full-page request. Tested with github.