### PR TITLE
[1.x] Fix token not being returned bug

### DIFF
--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -26,7 +26,7 @@ trait HasConnectedAccounts
     public function getTokenFor(string $provider, $default = null)
     {
         if ($this->hasTokenFor($provider)) {
-            $this->connectedAccounts
+            return $this->connectedAccounts
                 ->where('provider_name', Str::lower($provider))
                 ->first()
                 ->token;


### PR DESCRIPTION
The getTokenFor method suggests that you will receive a token back, currently you are only querying for the token and not returning it.
