### PR TITLE
[2.x] Added action for generating provider redirects

### DIFF
--- a/src/Actions/GenerateRedirectForProvider.php
+++ b/src/Actions/GenerateRedirectForProvider.php
@@ -9,9 +9,9 @@ class GenerateRedirectForProvider implements GeneratesProviderRedirect
 {
     /**
      * Generates the redirect for a given provider.
-     * 
+     *
      * @param  string  $provider
-     * 
+     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function generate(string $provider)

--- a/src/Actions/GenerateRedirectForProvider.php
+++ b/src/Actions/GenerateRedirectForProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace JoelButcher\Socialstream\Actions;
+
+use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
+use Laravel\Socialite\Facades\Socialite;
+
+class GenerateRedirectForProvider implements GeneratesProviderRedirect
+{
+    /**
+     * Generates the redirect for a given provider.
+     * 
+     * @param  string  $provider
+     * 
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function generate(string $provider)
+    {
+        return Socialite::driver($provider)->redirect();
+    }
+}

--- a/src/Contracts/GeneratesProviderRedirect.php
+++ b/src/Contracts/GeneratesProviderRedirect.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace JoelButcher\Socialstream\Contracts;
+
+interface GeneratesProviderRedirect
+{
+    /**
+     * Generates the redirect for a given provider.
+     * 
+     * @param  string  $provider
+     * 
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function generate(string $provider);
+}

--- a/src/Contracts/GeneratesProviderRedirect.php
+++ b/src/Contracts/GeneratesProviderRedirect.php
@@ -6,9 +6,9 @@ interface GeneratesProviderRedirect
 {
     /**
      * Generates the redirect for a given provider.
-     * 
+     *
      * @param  string  $provider
-     * 
+     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function generate(string $provider);

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -10,6 +10,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
+use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -69,11 +70,11 @@ class OAuthController extends Controller
      * @param  string  $provider
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function redirectToProvider(Request $request, string $provider)
+    public function redirectToProvider(Request $request, string $provider, GeneratesProviderRedirect $generator)
     {
         session()->put('origin_url', back()->getTargetUrl());
 
-        return Socialite::driver($provider)->redirect();
+        return $generator->generate($provider);
     }
 
     /**

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -134,7 +134,7 @@ class Socialstream
     }
 
     /**
-     * Register a class / callback that should be used for generating provider redirects
+     * Register a class / callback that should be used for generating provider redirects.
      *
      * @param  string  $callback
      * @return void

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -4,6 +4,7 @@ namespace JoelButcher\Socialstream;
 
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
+use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
 use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use JoelButcher\Socialstream\Contracts\SetsUserPasswords;
 
@@ -130,5 +131,16 @@ class Socialstream
     public static function handlesInvalidStateUsing(string $callback)
     {
         return app()->singleton(HandlesInvalidState::class, $callback);
+    }
+
+    /**
+     * Register a class / callback that should be used for generating provider redirects
+     *
+     * @param  string  $callback
+     * @return void
+     */
+    public static function generatesProvidersRedirectsUsing(string $callback)
+    {
+        return app()->singleton(GeneratesProviderRedirect::class, $callback);
     }
 }

--- a/stubs/app/Providers/SocialstreamServiceProvider.php
+++ b/stubs/app/Providers/SocialstreamServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Socialstream\CreateUserFromProvider;
 use App\Actions\Socialstream\HandleInvalidState;
 use App\Actions\Socialstream\SetUserPassword;
 use Illuminate\Support\ServiceProvider;
+use JoelButcher\Socialstream\Actions\GenerateRedirectForProvider;
 use JoelButcher\Socialstream\Socialstream;
 
 class SocialstreamServiceProvider extends ServiceProvider
@@ -32,5 +33,6 @@ class SocialstreamServiceProvider extends ServiceProvider
         Socialstream::createConnectedAccountsUsing(CreateConnectedAccount::class);
         Socialstream::setUserPasswordsUsing(SetUserPassword::class);
         Socialstream::handlesInvalidStateUsing(HandleInvalidState::class);
+        Socialstream::generatesProvidersRedirectsUsing(GenerateRedirectForProvider::class);
     }
 }


### PR DESCRIPTION
This PR introduces an action that allows developers to specify an action used to generate provider redirect URI's. By default, the `JoelButcher\Socialstream\Actions\GenerateRedirectForProvider` action is used. 

### Use case
As per #26, developers may need to specify scopes or additional parameters with the request:

```php
Socialite::driver($provider)
    ->scopes(['*'])
    ->with(['foo' => 'bar'])
    ->redirect()
```

This is now possible by extending the `GeneratesProviderRedirect` contract like so:

```php
<?php

namespace App\Actions;

use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;

class CustomAction implements GeneratesProviderRedirect
{
    /**
     * Generates the redirect for a given provider.
     * 
     * @param  string  $provider
     * 
     * @return \Symfony\Component\HttpFoundation\RedirectResponse
     */
    public function generate(string $provider)
    {
        //
    }
}
```

Developers must then specify this action in the `App\Providers\SocialstreamServiceProvider`:

```php
public function boot()
{
    Socialstream::generatesProvidersRedirectsUsing(\App\Actions\CustomAction::class);
}
```