### PR TITLE
[1.x] Use action to create connected accounts.

### DIFF
--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -23,7 +23,9 @@ trait HasConnectedAccounts
     public function currentConnectedAccount()
     {
         if (is_null($this->current_connected_account_id) && $this->id) {
-            $this->switchConnectedAccount($this->personalTeam());
+            $this->switchConnectedAccount(
+                $this->connectedAccounts()->orderBy('created_at')->first()
+            );
         }
 
         return $this->belongsTo(Socialstream::connectedAccountModel(), 'current_connected_account_id');
@@ -37,7 +39,7 @@ trait HasConnectedAccounts
      */
     public function switchConnectedAccount($connectedAccount)
     {
-        if ($this->ownsConnectedAccount($connectedAccount)) {
+        if (! $this->ownsConnectedAccount($connectedAccount)) {
             return false;
         }
 

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JoelButcher\Socialstream\Actions;
+namespace App\Actions\Socialstream;
 
 use App\Models\User;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;

--- a/stubs/app/Actions/Socialstream/CreateUserFromProvider.php
+++ b/stubs/app/Actions/Socialstream/CreateUserFromProvider.php
@@ -4,11 +4,29 @@ namespace App\Actions\Socialstream;
 
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use Laravel\Socialite\Contracts\User as ProviderUser;
 
 class CreateUserFromProvider implements CreatesUserFromProvider
 {
+    /**
+     * The creates connected accounts instance.
+     *
+     * @var \JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts
+     */
+    public $createsConnectedAccounts;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts  $createsConnectedAccounts
+     */
+    public function __construct(CreatesConnectedAccounts $createsConnectedAccounts)
+    {
+        $this->createsConnectedAccounts = $createsConnectedAccounts;
+    }
+
     /**
      * Create a new user from a social provider user.
      *
@@ -26,29 +44,9 @@ class CreateUserFromProvider implements CreatesUserFromProvider
                 $user->markEmailAsVerified();
 
                 $user->switchConnectedAccount(
-                    $this->createConnectedAccount($user, $provider, $providerUser)
+                    $this->createsConnectedAccounts->create($user, $provider, $providerUser)
                 );
             });
         });
-    }
-
-    /**
-     * Create a connected account for the user.
-     *
-     * @param  \App\Models\User  $user
-     * @param  string  $provider
-     * @param  \Laravel\Socialite\Contracts\User  $providerUser
-     * @return \JoelButcher\Socialstream\ConnectedAccount
-     */
-    protected function createConnectedAccount(User $user, string $provider, ProviderUser $providerUser)
-    {
-        return $user->connectedAccounts()->create([
-            'provider_name' => strtolower($provider),
-            'provider_id' => $providerUser->getId(),
-            'token' => $providerUser->token,
-            'secret' => $providerUser->tokenSecret ?? null,
-            'refresh_token' => $providerUser->refreshToken ?? null,
-            'expires_at' => $providerUser->expiresAt ?? null,
-        ]);
     }
 }

--- a/stubs/app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
+++ b/stubs/app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
@@ -5,11 +5,29 @@ namespace App\Actions\Socialstream;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use Laravel\Socialite\Contracts\User as ProviderUserContract;
 
 class CreateUserFromProvider implements CreatesUserFromProvider
 {
+    /**
+     * The creates connected accounts instance.
+     *
+     * @var \JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts
+     */
+    public $createsConnectedAccounts;
+
+    /**
+     * Create a new action instance.
+     *
+     * @param  \JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts  $createsConnectedAccounts
+     */
+    public function __construct(CreatesConnectedAccounts $createsConnectedAccounts)
+    {
+        $this->createsConnectedAccounts = $createsConnectedAccounts;
+    }
+
     /**
      * Create a new user from a social provider user.
      *
@@ -27,32 +45,12 @@ class CreateUserFromProvider implements CreatesUserFromProvider
                 $user->markEmailAsVerified();
 
                 $user->switchConnectedAccount(
-                    $this->createConnectedAccount($user, $provider, $providerUser)
+                    $this->createsConnectedAccounts->create($user, $provider, $providerUser)
                 );
 
                 $this->createTeam($user);
             });
         });
-    }
-
-    /**
-     * Create a connected account for the user.
-     *
-     * @param  \App\Models\User  $user
-     * @param  string  $provider
-     * @param  \Laravel\Socialite\Contracts\User  $providerUser
-     * @return \JoelButcher\Socialstream\ConnectedAccount
-     */
-    protected function createConnectedAccount(User $user, string $provider, ProviderUserContract $providerUser)
-    {
-        return $user->connectedAccounts()->create([
-            'provider_name' => strtolower($provider),
-            'provider_id' => $providerUser->getId(),
-            'token' => $providerUser->token,
-            'secret' => $providerUser->tokenSecret ?? null,
-            'refresh_token' => $providerUser->refreshToken ?? null,
-            'expires_at' => $providerUser->expiresAt ?? null,
-        ]);
     }
 
     /**

--- a/tests/CreateUserFromProviderTest.php
+++ b/tests/CreateUserFromProviderTest.php
@@ -2,7 +2,10 @@
 
 namespace JoelButcher\Socialstream\Tests;
 
+use App\Actions\Socialstream\CreateConnectedAccount;
 use App\Actions\Socialstream\CreateUserFromProvider;
+use App\Models\ConnectedAccount;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Socialite\One\User as OAuth1User;
 use Laravel\Socialite\Two\User as OAuth2User;
@@ -19,12 +22,12 @@ class CreateUserFromProviderTest extends TestCase
         $providerUser->email = 'joel@socialstream.com';
         $providerUser->token = Str::random(64);
 
-        $action = new CreateUserFromProvider;
+        $action = new CreateUserFromProvider(new CreateConnectedAccount);
 
         $user = $action->create('github', $providerUser);
 
         $this->assertEquals($providerUser->email, $user->email);
-        $this->assertCount(1, $user->connectedAccounts);
+        $this->assertInstanceOf(ConnectedAccount::class, $user->currentConnectedAccount);
     }
 
     public function test_user_can_be_created_from_o_auth_2_provider()
@@ -37,12 +40,13 @@ class CreateUserFromProviderTest extends TestCase
         $providerUser->email = 'joel@socialstream.com';
         $providerUser->token = Str::random(64);
 
-        $action = new CreateUserFromProvider;
+        $action = new CreateUserFromProvider(new CreateConnectedAccount);
 
         $user = $action->create('github', $providerUser);
+        $user->fresh();
 
         $this->assertEquals($providerUser->email, $user->email);
-        $this->assertCount(1, $user->connectedAccounts);
+        $this->assertInstanceOf(ConnectedAccount::class, $user->currentConnectedAccount);
     }
 
     protected function migrate()


### PR DESCRIPTION
This PR injects the `CreatesConnectedAccounts` contract into `CreateUserFromProvider`. The goal is to reduce code duplication.