### PR TITLE
[2.x] Connected account details

### DIFF
--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -23,7 +23,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('email')->nullable();
             $table->string('telephone')->nullable();
             $table->string('avatar_path')->nullable();
-            $table->string('token');    
+            $table->string('token');
             $table->string('secret')->nullable(); // OAuth1
             $table->string('refresh_token')->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2

--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -16,9 +16,14 @@ class CreateConnectedAccountsTable extends Migration
         Schema::create('connected_accounts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id');
-            $table->string('provider_name');
-            $table->string('provider_id');
-            $table->string('token');
+            $table->string('provider');
+            $table->string('id');
+            $table->string('name')->nullable();
+            $table->string('nickname')->nullable();
+            $table->string('email')->nullable();
+            $table->string('telephone')->nullable();
+            $table->string('avatar_path')->nullable();
+            $table->string('token');    
             $table->string('secret')->nullable(); // OAuth1
             $table->string('refresh_token')->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2

--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -17,7 +17,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->id();
             $table->foreignId('user_id');
             $table->string('provider');
-            $table->string('id');
+            $table->string('provider_id');
             $table->string('name')->nullable();
             $table->string('nickname')->nullable();
             $table->string('email')->nullable();

--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -8,6 +8,16 @@ use Laravel\Jetstream\Jetstream;
 abstract class ConnectedAccount extends Model
 {
     /**
+     * Get the credentials used for authenticating services.
+     *
+     * @return \JoelButcher\Socialstream\Credentials
+     */
+    public function getCredentials()
+    {
+        return new Credentials($this);
+    }
+
+    /**
      * Get user of the connected account.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Contracts/Credentials.php
+++ b/src/Contracts/Credentials.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JoelButcher\Socialstream\Contracts;
+
+use DateTimeInterface;
+
+interface Credentials
+{
+    /**
+     * Get the ID for the credentials.
+     *
+     * @return string
+     */
+    public function getId();
+
+    /**
+     * Get token for the credentials.
+     *
+     * @return string
+     */
+    public function getToken();
+
+    /**
+     * Get the token secret for the credentials
+     *
+     * @return string|null
+     */
+    public function getTokenSecret();
+
+    /**
+     * Get the refresh token for the credentials
+     *
+     * @return string|null
+     */
+    public function getRefreshToken();
+
+    /**
+     * Get the expiry date for the credentials
+     *
+     * @return DateTimeInterface|null
+     */
+    public function getExpiry();
+}

--- a/src/Contracts/Credentials.php
+++ b/src/Contracts/Credentials.php
@@ -21,21 +21,21 @@ interface Credentials
     public function getToken();
 
     /**
-     * Get the token secret for the credentials
+     * Get the token secret for the credentials.
      *
      * @return string|null
      */
     public function getTokenSecret();
 
     /**
-     * Get the refresh token for the credentials
+     * Get the refresh token for the credentials.
      *
      * @return string|null
      */
     public function getRefreshToken();
 
     /**
-     * Get the expiry date for the credentials
+     * Get the expiry date for the credentials.
      *
      * @return DateTimeInterface|null
      */

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace JoelButcher\Socialstream;
+
+use DateTime;
+use DateTimeInterface;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JoelButcher\Socialstream\Contracts\Credentials as CredentialsContract;
+use JsonSerializable;
+
+class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSerializable
+{
+    /**
+     * The credentials user ID.
+     *
+     * @var string
+     */
+    protected $id;
+    
+    /**
+     * The credentials token.
+     *
+     * @var string
+     */
+    protected $token;
+
+    /**
+     * The credentials token secret.
+     *
+     * @var string|null
+     */
+    protected $tokenSecret;
+
+    /**
+     * The credentials refresh token.
+     *
+     * @var string|null
+     */
+    protected $refreshToken;
+
+    /**
+     * The credentials expiry.
+     *
+     * @var DateTimeInterface|null
+     */
+    protected $expiry;
+
+    /**
+     * Create a new credentials instance.
+     *
+     * @param  \JoelButcher\Socialstream\ConnectedAccount  $connectedAccount
+     */
+    public function __construct(ConnectedAccount $connectedAccount) {
+        $this->id = $connectedAccount->provider_id;
+        $this->token = $connectedAccount->token;
+        $this->tokenSecret = $connectedAccount->secret;
+        $this->refreshToken = $connectedAccount->refresh_token;
+        $this->expiry = $connectedAccount->expires_at;
+    }
+
+    /**
+     * Get the ID for the credentials.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get token for the credentials.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * Get the token secret for the credentials
+     *
+     * @return string|null
+     */
+    public function getTokenSecret()
+    {
+        return $this->tokenSecret;
+    }
+
+    /**
+     * Get the refresh token for the credentials
+     *
+     * @return string|null
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
+    }
+
+    /**
+     * Get the expiry date for the credentials
+     *
+     * @return DateTimeInterface|null
+     */
+    public function getExpiry()
+    {
+        if (is_null($this->expiry)) {
+            return null;
+        }
+
+        return new DateTime($this->expiry);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'id' => $this->getId(),
+            'token' => $this->getToken(),
+            'token_secret' => $this->getTokenSecret(),
+            'refresh_token' => $this->getRefreshToken(),
+            'expiry' => $this->getExpiry(),
+        ];
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return mixed
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the object instance to a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this->toJson());
+    }
+}

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -17,7 +17,7 @@ class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSeria
      * @var string
      */
     protected $id;
-    
+
     /**
      * The credentials token.
      *
@@ -51,7 +51,8 @@ class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSeria
      *
      * @param  \JoelButcher\Socialstream\ConnectedAccount  $connectedAccount
      */
-    public function __construct(ConnectedAccount $connectedAccount) {
+    public function __construct(ConnectedAccount $connectedAccount)
+    {
         $this->id = $connectedAccount->provider_id;
         $this->token = $connectedAccount->token;
         $this->tokenSecret = $connectedAccount->secret;
@@ -80,7 +81,7 @@ class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSeria
     }
 
     /**
-     * Get the token secret for the credentials
+     * Get the token secret for the credentials.
      *
      * @return string|null
      */
@@ -90,7 +91,7 @@ class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSeria
     }
 
     /**
-     * Get the refresh token for the credentials
+     * Get the refresh token for the credentials.
      *
      * @return string|null
      */
@@ -100,7 +101,7 @@ class Credentials implements CredentialsContract, Arrayable, Jsonable, JsonSeria
     }
 
     /**
-     * Get the expiry date for the credentials
+     * Get the expiry date for the credentials.
      *
      * @return DateTimeInterface|null
      */

--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -71,7 +71,7 @@ trait HasConnectedAccounts
      */
     public function hasTokenFor(string $provider)
     {
-        return $this->connectedAccounts->contains('provider_name', Str::lower($provider));
+        return $this->connectedAccounts->contains('provider', Str::lower($provider));
     }
 
     /**
@@ -84,7 +84,7 @@ trait HasConnectedAccounts
     {
         if ($this->hasTokenFor($provider)) {
             return $this->connectedAccounts
-                ->where('provider_name', Str::lower($provider))
+                ->where('provider', Str::lower($provider))
                 ->first()
                 ->token;
         }
@@ -94,17 +94,17 @@ trait HasConnectedAccounts
 
     /**
      * Attempt to find a connected account that belongs to the user,
-     * for the given provider and provider id.
+     * for the given provider and ID.
      *
      * @param  string  $provider
-     * @param  string  $providerId
+     * @param  string  $id
      * @return \Laravel\Jetstream\ConnectedAccount
      */
-    public function getConnectedAccountFor(string $provider, string $providerId)
+    public function getConnectedAccountFor(string $provider, string $id)
     {
         return $this->connectedAccounts
-            ->where('provider_name', $provider)
-            ->where('provider_id', $providerId)
+            ->where('provider', $provider)
+            ->where('id', $id)
             ->first();
     }
 

--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -104,7 +104,7 @@ trait HasConnectedAccounts
     {
         return $this->connectedAccounts
             ->where('provider', $provider)
-            ->where('id', $id)
+            ->where('provider_id', $id)
             ->first();
     }
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -99,8 +99,8 @@ class OAuthController extends Controller
         }
 
         $account = ConnectedAccount::firstWhere([
-            'provider_id' => $providerAccount->getId(),
-            'provider_name' => $provider,
+            'id' => $providerAccount->getId(),
+            'provider' => $provider,
         ]);
 
         // Authenticated...

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -99,8 +99,8 @@ class OAuthController extends Controller
         }
 
         $account = ConnectedAccount::firstWhere([
-            'id' => $providerAccount->getId(),
             'provider' => $provider,
+            'provider_id' => $providerAccount->getId(),
         ]);
 
         // Authenticated...

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -31,7 +31,7 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
                 'token' => $providerUser->token,
                 'secret' => $providerUser->tokenSecret ?? null,
                 'refresh_token' => $providerUser->refreshToken ?? null,
-                'expires_at' => $providerUser->expiresAt ?? null,
+                'expires_at' => property_exists($providerUser, 'expiresIn') ? now()->addSeconds($providerUser->expiresIn) : null,
             ])->save();
 
             return $connectedAccount;
@@ -47,7 +47,7 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
             'token' => $providerUser->token,
             'secret' => $providerUser->tokenSecret ?? null,
             'refresh_token' => $providerUser->refreshToken ?? null,
-            'expires_at' => $providerUser->expiresAt ?? null,
+            'expires_at' => property_exists($providerUser, 'expiresIn') ? now()->addSeconds($providerUser->expiresIn) : null,
         ]);
     }
 }

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -39,9 +39,9 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
 
         return $user->connectedAccounts()->create([
             'provider' => strtolower($provider),
-            'id' => $providerUser->getId(),
+            'provider_id' => $providerUser->getId(),
             'name' => $providerUser->getName(),
-            'provider_id' => $providerUser->getNickname(),
+            'nickname' => $providerUser->getNickname(),
             'email' => $providerUser->getEmail(),
             'avatar_path' => $providerUser->getAvatar(),
             'token' => $providerUser->token,

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -22,8 +22,12 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
             $connectedAccount = $user->getTokenFor($provider);
 
             $connectedAccount->forceFill([
-                'provider_name' => strtolower($provider),
-                'provider_id' => $providerUser->getId(),
+                'provider' => strtolower($provider),
+                'id' => $providerUser->getId(),
+                'name' => $providerUser->getName(),
+                'nickname' => $providerUser->getNickname(),
+                'email' => $providerUser->getEmail(),
+                'avatar_path' => $providerUser->getAvatar(),
                 'token' => $providerUser->token,
                 'secret' => $providerUser->tokenSecret ?? null,
                 'refresh_token' => $providerUser->refreshToken ?? null,
@@ -34,8 +38,12 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
         }
 
         return $user->connectedAccounts()->create([
-            'provider_name' => strtolower($provider),
-            'provider_id' => $providerUser->getId(),
+            'provider' => strtolower($provider),
+            'id' => $providerUser->getId(),
+            'name' => $providerUser->getName(),
+            'nickname' => $providerUser->getNickname(),
+            'email' => $providerUser->getEmail(),
+            'avatar_path' => $providerUser->getAvatar(),
             'token' => $providerUser->token,
             'secret' => $providerUser->tokenSecret ?? null,
             'refresh_token' => $providerUser->refreshToken ?? null,

--- a/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
+++ b/stubs/app/Actions/Socialstream/CreateConnectedAccount.php
@@ -23,7 +23,7 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
 
             $connectedAccount->forceFill([
                 'provider' => strtolower($provider),
-                'id' => $providerUser->getId(),
+                'provider_id' => $providerUser->getId(),
                 'name' => $providerUser->getName(),
                 'nickname' => $providerUser->getNickname(),
                 'email' => $providerUser->getEmail(),
@@ -41,7 +41,7 @@ class CreateConnectedAccount implements CreatesConnectedAccounts
             'provider' => strtolower($provider),
             'id' => $providerUser->getId(),
             'name' => $providerUser->getName(),
-            'nickname' => $providerUser->getNickname(),
+            'provider_id' => $providerUser->getNickname(),
             'email' => $providerUser->getEmail(),
             'avatar_path' => $providerUser->getAvatar(),
             'token' => $providerUser->token,

--- a/stubs/app/Actions/Socialstream/CreateUserFromProvider.php
+++ b/stubs/app/Actions/Socialstream/CreateUserFromProvider.php
@@ -43,9 +43,7 @@ class CreateUserFromProvider implements CreatesUserFromProvider
             ]), function (User $user) use ($provider, $providerUser) {
                 $user->markEmailAsVerified();
 
-                $user->switchConnectedAccount(
-                    $this->createsConnectedAccounts->create($user, $provider, $providerUser)
-                );
+                $this->createsConnectedAccounts->create($user, $provider, $providerUser);
             });
         });
     }

--- a/stubs/app/Models/ConnectedAccount.php
+++ b/stubs/app/Models/ConnectedAccount.php
@@ -20,8 +20,8 @@ class ConnectedAccount extends SocialstreamConnectedAccount
      * @var array
      */
     protected $fillable = [
-        'provider_name',
-        'provider_id',
+        'provider',
+        'id',
         'token',
         'refresh_token',
         'expires_at',

--- a/stubs/app/Models/ConnectedAccount.php
+++ b/stubs/app/Models/ConnectedAccount.php
@@ -21,7 +21,11 @@ class ConnectedAccount extends SocialstreamConnectedAccount
      */
     protected $fillable = [
         'provider',
-        'id',
+        'provider_id',
+        'name',
+        'nickname',
+        'email',
+        'avatar_path',
         'token',
         'refresh_token',
         'expires_at',

--- a/tests/CreateUserFromProviderTest.php
+++ b/tests/CreateUserFromProviderTest.php
@@ -33,7 +33,7 @@ class CreateUserFromProviderTest extends TestCase
         $connectedAccount = $user->currentConnectedAccount;
         $this->assertInstanceOf(ConnectedAccount::class, $connectedAccount);
         $this->assertEquals($providerUser->id, $connectedAccount->provider_id);
-        
+
         $credentials = $connectedAccount->getCredentials();
         $this->assertInstanceOf(Credentials::class, $credentials);
         $this->assertEquals($providerUser->id, $credentials->getId());

--- a/tests/CreateUserFromProviderTest.php
+++ b/tests/CreateUserFromProviderTest.php
@@ -5,8 +5,10 @@ namespace JoelButcher\Socialstream\Tests;
 use App\Actions\Socialstream\CreateConnectedAccount;
 use App\Actions\Socialstream\CreateUserFromProvider;
 use App\Models\ConnectedAccount;
+use DateTimeInterface;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use JoelButcher\Socialstream\Contracts\Credentials;
 use Laravel\Socialite\One\User as OAuth1User;
 use Laravel\Socialite\Two\User as OAuth2User;
 
@@ -27,7 +29,17 @@ class CreateUserFromProviderTest extends TestCase
         $user = $action->create('github', $providerUser);
 
         $this->assertEquals($providerUser->email, $user->email);
-        $this->assertInstanceOf(ConnectedAccount::class, $user->currentConnectedAccount);
+        
+        $connectedAccount = $user->currentConnectedAccount;
+        $this->assertInstanceOf(ConnectedAccount::class, $connectedAccount);
+        $this->assertEquals($providerUser->id, $connectedAccount->provider_id);
+        
+        $credentials = $connectedAccount->getCredentials();
+        $this->assertInstanceOf(Credentials::class, $credentials);
+        $this->assertEquals($providerUser->id, $credentials->getId());
+        $this->assertEquals($providerUser->token, $credentials->getToken());
+        $this->assertNull($credentials->getRefreshToken());
+        $this->assertNull($credentials->getExpiry());
     }
 
     public function test_user_can_be_created_from_o_auth_2_provider()
@@ -39,14 +51,24 @@ class CreateUserFromProviderTest extends TestCase
         $providerUser->name = 'Joel Butcher';
         $providerUser->email = 'joel@socialstream.com';
         $providerUser->token = Str::random(64);
+        $providerUser->expiresIn = 3600;
 
         $action = new CreateUserFromProvider(new CreateConnectedAccount);
 
         $user = $action->create('github', $providerUser);
-        $user->fresh();
-
+        
         $this->assertEquals($providerUser->email, $user->email);
-        $this->assertInstanceOf(ConnectedAccount::class, $user->currentConnectedAccount);
+        
+        $connectedAccount = $user->currentConnectedAccount;
+        $this->assertInstanceOf(ConnectedAccount::class, $connectedAccount);
+        $this->assertEquals($providerUser->id, $connectedAccount->provider_id);
+
+        $credentials = $connectedAccount->getCredentials();
+        $this->assertInstanceOf(Credentials::class, $credentials);
+        $this->assertEquals($providerUser->id, $credentials->getId());
+        $this->assertEquals($providerUser->token, $credentials->getToken());
+        $this->assertNull($credentials->getTokenSecret());
+        $this->assertInstanceOf(DateTimeInterface::class, $credentials->getExpiry());
     }
 
     protected function migrate()

--- a/tests/CreateUserFromProviderTest.php
+++ b/tests/CreateUserFromProviderTest.php
@@ -29,7 +29,7 @@ class CreateUserFromProviderTest extends TestCase
         $user = $action->create('github', $providerUser);
 
         $this->assertEquals($providerUser->email, $user->email);
-        
+
         $connectedAccount = $user->currentConnectedAccount;
         $this->assertInstanceOf(ConnectedAccount::class, $connectedAccount);
         $this->assertEquals($providerUser->id, $connectedAccount->provider_id);
@@ -56,9 +56,9 @@ class CreateUserFromProviderTest extends TestCase
         $action = new CreateUserFromProvider(new CreateConnectedAccount);
 
         $user = $action->create('github', $providerUser);
-        
+
         $this->assertEquals($providerUser->email, $user->email);
-        
+
         $connectedAccount = $user->currentConnectedAccount;
         $this->assertInstanceOf(ConnectedAccount::class, $connectedAccount);
         $this->assertEquals($providerUser->id, $connectedAccount->provider_id);


### PR DESCRIPTION
This PR adds additional information from Socialite to the connected accounts table:

- Name,
- Nickname
- Email
- Avatar Path

This PR also introduces a new `Credentials` class which can be used for authenticating with a providers API's, if desired. Simply call the following code to retrieve an instance.

```php
$connectedAccount->getCredentials()
```

The credentials class adheres to `Arrayable`, `Jsonable` and `JsonSerializable` contracts, as well as the following contract

```php
<?php

namespace JoelButcher\Socialstream\Contracts;

use DateTimeInterface;

interface Credentials
{
    /**
     * Get the ID for the credentials.
     *
     * @return string
     */
    public function getId();

    /**
     * Get token for the credentials.
     *
     * @return string
     */
    public function getToken();

    /**
     * Get the token secret for the credentials
     *
     * @return string|null
     */
    public function getTokenSecret();

    /**
     * Get the refresh token for the credentials
     *
     * @return string|null
     */
    public function getRefreshToken();

    /**
     * Get the expiry date for the credentials
     *
     * @return DateTimeInterface|null
     */
    public function getExpiry();
}

```