### PR TITLE
Make the shared data customizable

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -23,11 +23,7 @@ class ShareInertiaData
                     'providers' => Socialstream::providers(),
                     'hasPassword' => $request->user() && ! is_null($request->user()->password),
                     'connectedAccounts' => $request->user() ? $request->user()->connectedAccounts->map(function ($account) {
-                        return (object) [
-                            'id' => $account->id,
-                            'provider' => $account->provider,
-                            'created_at' => (new \DateTime($account->created_at))->format('d/m/Y H:i'),
-                        ];
+                        return (object) $account->jsonSerialize();
                     }) : [],
                 ];
             },

--- a/stubs/app/Models/ConnectedAccount.php
+++ b/stubs/app/Models/ConnectedAccount.php
@@ -41,7 +41,7 @@ class ConnectedAccount extends SocialstreamConnectedAccount
         'updated' => ConnectedAccountUpdated::class,
         'deleted' => ConnectedAccountDeleted::class,
     ];
-    
+
     public function jsonSerialize()
     {
         return [

--- a/stubs/app/Models/ConnectedAccount.php
+++ b/stubs/app/Models/ConnectedAccount.php
@@ -41,4 +41,13 @@ class ConnectedAccount extends SocialstreamConnectedAccount
         'updated' => ConnectedAccountUpdated::class,
         'deleted' => ConnectedAccountDeleted::class,
     ];
+    
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->id,
+            'provider' => $this->provider,
+            'created_at' => (new \DateTime($this->created_at))->format('d/m/Y H:i'),
+        ];
+    }
 }


### PR DESCRIPTION
The package-provided middleware returns a fix set of properties. Especially the pre-formatted date is hard to customize.
My suggestion is to use the jsonSerialize method in the model stub to return in inertia middleware.

So I can easy customize the properties I need for customizing the presentation. E.g. I need german formatted timestamp.
