### PR TITLE
[2.x] Move shared inertia data responsibility to ConnectedAccounts abstract

### DIFF
--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -26,4 +26,18 @@ abstract class ConnectedAccount extends Model
     {
         return $this->belongsTo(Jetstream::userModel(), 'user_id');
     }
+
+    /**
+     * Get the data that should be shared with Inertia.
+     *
+     * @return array
+     */
+    public function getSharedInertiaData()
+    {
+        return [
+            'id' => $this->id,
+            'provider' => $this->provider,
+            'created_at' => (new \DateTime($this->created_at))->format('d/m/Y H:i'),
+        ];
+    }
 }

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -3,6 +3,7 @@
 namespace JoelButcher\Socialstream\Http\Middleware;
 
 use Inertia\Inertia;
+use JoelButcher\Socialstream\ConnectedAccount;
 use JoelButcher\Socialstream\Socialstream;
 
 class ShareInertiaData
@@ -22,13 +23,10 @@ class ShareInertiaData
                     'show' => Socialstream::show(),
                     'providers' => Socialstream::providers(),
                     'hasPassword' => $request->user() && ! is_null($request->user()->password),
-                    'connectedAccounts' => $request->user() ? $request->user()->connectedAccounts->map(function ($account) {
-                        return (object) [
-                            'id' => $account->id,
-                            'provider' => $account->provider,
-                            'created_at' => (new \DateTime($account->created_at))->format('d/m/Y H:i'),
-                        ];
-                    }) : [],
+                    'connectedAccounts' => $request->user() ? $request->user()->connectedAccounts
+                        ->map(function (ConnectedAccount $account) {
+                            return (object) $account->getSharedInertiaData();
+                        }) : [],
                 ];
             },
         ]));


### PR DESCRIPTION
This PR addresses several issues with #34. Most importantly, the overriding of `jsonSerialize`. I also moves the responsibility of this method to the abstract so that developers don't have to republish the ConnectedAccount model.

The key benefit of this change is the ability to customise and override the data shared to Inertia:

```php
/**
 * Get the data that should be shared with Inertia.
 *
 * @return array
 */
public function getSharedInertiaData()
{
    return [
        //
    ]
}
```