### PR TITLE
Fix conflict doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "doctrine/dbal": "^3.0",
+        "doctrine/dbal": "^2.9|^3.0",
         "illuminate/support": "^8.0",
         "laravel/jetstream": "^2.0.0",
         "laravel/socialite": "^5.0"


### PR DESCRIPTION
Fix version conflict:  doctrine/dbal 3.0.0 with laravel nova 3.19.1 (doctrine/dbal 2.9)