### PR TITLE
Remove password focus & Fix error validation

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -127,11 +127,7 @@
             removeConnectedAccount(id) {
                 this.form.post(route('connected-accounts.destroy', {id}), {
                     preserveScroll: true,
-                    onSuccess: () => {
-                        if (! this.form.hasErrors()) {
-                            this.confirmingRemove = false;
-                        }
-                    },
+                    onSuccess: () => (this.confirmingRemove = false),
                 });
             },
         }

--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -110,10 +110,6 @@
                 this.accountId = id;
 
                 this.confirmingRemove = true;
-
-                setTimeout(() => {
-                    this.$refs.password.focus();
-                }, 250);
             },
 
             hasAccountForProvider(provider) {


### PR DESCRIPTION
- Remove password focus since there is no password field to focus.
- Remove form .hasErrors() since this method do not exits on inertia form (probably existed on laravel-jetstream forms). Also there is no forms validation for this request.