### PR TITLE
[2.x] Change connected date format to same as jetstream

### DIFF
--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -37,7 +37,7 @@ abstract class ConnectedAccount extends Model
         return [
             'id' => $this->id,
             'provider' => $this->provider,
-            'created_at' => (new \DateTime($this->created_at))->format('d/m/Y H:i'),
+            'created_at' => optional($this->created_at)->diffForHumans(),
         ];
     }
 }

--- a/src/Http/Livewire/ConnectedAccountsForm.php
+++ b/src/Http/Livewire/ConnectedAccountsForm.php
@@ -88,7 +88,7 @@ class ConnectedAccountsForm extends Component
                 return (object) [
                     'id' => $account->id,
                     'provider_name' => $account->provider,
-                    'created_at' => (new \DateTime($account->created_at))->format('d/m/Y H:i'),
+                    'created_at' => optional($account->created_at)->diffForHumans(),
                 ];
             });
     }

--- a/stubs/inertia/resources/js/Socialstream/ConnectedAccount.vue
+++ b/stubs/inertia/resources/js/Socialstream/ConnectedAccount.vue
@@ -17,7 +17,7 @@
                     </div>
 
                     <div v-if="createdAt !== null" class="text-xs text-gray-500">
-                        Connected on {{ createdAt }}
+                        Connected {{ createdAt }}
                     </div>
 
                     <div v-else class="text-xs text-gray-500">

--- a/stubs/livewire/resources/views/components/connected-account.blade.php
+++ b/stubs/livewire/resources/views/components/connected-account.blade.php
@@ -35,7 +35,7 @@
 
                 @if (! is_null($createdAt))
                     <div class="text-xs text-gray-500">
-                        Connected on {{ $createdAt }}
+                        Connected {{ $createdAt }}
                     </div>
                 @else
                     <div class="text-xs text-gray-500">


### PR DESCRIPTION
This pull request will change the "Connected on ..." format to the same as Jetstream Api Tokens last used ago.
It will changed the date format from 'd/m/Y H:i', since its not a unified format ~~and not customizable~~, to the diffForHumans() function.

Example: "6 minutes ago".

