### PR TITLE
[2.x] Define data shared method on model abstract.

### DIFF
--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -34,6 +34,16 @@ abstract class ConnectedAccount extends Model
      */
     public function getSharedInertiaData()
     {
+        return $this->getSharedData();
+    }
+
+    /**
+     * Get the data that should be shared.
+     *
+     * @return array
+     */
+    public function getSharedData()
+    {
         return [
             'id' => $this->id,
             'provider' => $this->provider,

--- a/src/Http/Livewire/ConnectedAccountsForm.php
+++ b/src/Http/Livewire/ConnectedAccountsForm.php
@@ -4,6 +4,7 @@ namespace JoelButcher\Socialstream\Http\Livewire;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use JoelButcher\Socialstream\ConnectedAccount;
 use JoelButcher\Socialstream\Socialstream;
 use Laravel\Jetstream\InteractsWithBanner;
 use Livewire\Component;
@@ -84,12 +85,8 @@ class ConnectedAccountsForm extends Component
     public function getAccountsProperty()
     {
         return Auth::user()->connectedAccounts
-            ->map(function ($account) {
-                return (object) [
-                    'id' => $account->id,
-                    'provider_name' => $account->provider,
-                    'created_at' => optional($account->created_at)->diffForHumans(),
-                ];
+            ->map(function (ConnectedAccount $account) {
+                return (object) $account->getSharedData();
             });
     }
 


### PR DESCRIPTION
Adds a new `getSharedData` method to the Connected Account abstract class. This method defines the data exposed to Livewire / Inertia for use in the views.