### PR TITLE
[feature] optional auto_create setting to improve login UX

### DIFF
--- a/config/socialstream.php
+++ b/config/socialstream.php
@@ -53,7 +53,7 @@ return [
     |
     */
 
-    'auto_create' => env('SOCIALSTREAM_AUTO_CREATE', false),
+    'autoCreate' => env('SOCIALSTREAM_AUTO_CREATE', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/socialstream.php
+++ b/config/socialstream.php
@@ -45,6 +45,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Socialstream Auto Create Account
+    |--------------------------------------------------------------------------
+    |
+    | This value is used to determine whether to auto create new account
+    | when a new user attempt to login.
+    |
+    */
+
+    'auto_create' => env('SOCIALSTREAM_AUTO_CREATE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Socialstream Providers
     |--------------------------------------------------------------------------
     |
@@ -60,4 +72,5 @@ return [
     'providers' => [
         // 'github',
     ],
+
 ];

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -125,7 +125,7 @@ class OAuthController extends Controller
         }
 
         // Registration...
-        if (session()->get('origin_url') === route('register')) {
+        if (! $account || session()->get('origin_url') === route('register')) {
             if ($account) {
                 return redirect()->route('register')->withErrors(
                     __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider])
@@ -149,12 +149,6 @@ class OAuthController extends Controller
             $this->guard->login($user, config('socialstream.remember'));
 
             return redirect(config('fortify.home'));
-        }
-
-        if (! $account) {
-            return redirect()->route('login')->withErrors(
-                __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
-            );
         }
 
         $this->guard->login($account->user, config('socialstream.remember'));

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -124,7 +124,7 @@ class OAuthController extends Controller
             ]);
         }
 
-        $is_autocreate = config('socialstream.auto_create');
+        $is_autocreate = config('socialstream.autoCreate');
 
         // Registration...
         if ((! $account && $is_autocreate) || session()->get('origin_url') === route('register')) {

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -124,10 +124,10 @@ class OAuthController extends Controller
             ]);
         }
 
-        $is_autocreate = config('socialstream.autoCreate');
+        $isAutocreate = config('socialstream.autoCreate');
 
         // Registration...
-        if ((! $account && $is_autocreate) || session()->get('origin_url') === route('register')) {
+        if ((! $account && $isAutocreate) || session()->get('origin_url') === route('register')) {
             if ($account) {
                 return redirect()->route('register')->withErrors(
                     __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider])
@@ -153,7 +153,7 @@ class OAuthController extends Controller
             return redirect(config('fortify.home'));
         }
 
-        if (! $account && ! $is_autocreate) {
+        if (! $account && ! $isAutocreate) {
             return redirect()->route('login')->withErrors(
                 __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
             );

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -124,8 +124,10 @@ class OAuthController extends Controller
             ]);
         }
 
+        $is_autocreate = config('socialstream.auto_create');
+
         // Registration...
-        if (! $account || session()->get('origin_url') === route('register')) {
+        if ((! $account && $is_autocreate) || session()->get('origin_url') === route('register')) {
             if ($account) {
                 return redirect()->route('register')->withErrors(
                     __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider])
@@ -149,6 +151,12 @@ class OAuthController extends Controller
             $this->guard->login($user, config('socialstream.remember'));
 
             return redirect(config('fortify.home'));
+        }
+
+        if (! $account && ! $is_autocreate) {
+            return redirect()->route('login')->withErrors(
+                __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
+            );
         }
 
         $this->guard->login($account->user, config('socialstream.remember'));


### PR DESCRIPTION
This change/enhancement is based on UX optimisation consideration.

**Current Issue**
First-time guest visiting guarded pages will be redirected to login page.
Clicking social media icons at login page will return an error, which is counter-intuitive from UX perspective.

**Enhancement**
First-time guest can quickly get onboard when they visited links that required authentication.

