### PR TITLE
[2.x] Feature: Create account on login

### DIFF
--- a/config/socialstream.php
+++ b/config/socialstream.php
@@ -76,5 +76,5 @@ return [
 
     'features' => [
         // Features::createAccountOnFirstLogin(),
-    ]
+    ],
 ];

--- a/config/socialstream.php
+++ b/config/socialstream.php
@@ -1,5 +1,7 @@
 <?php
 
+use JoelButcher\Socialstream\Features;
+
 return [
 
     /*
@@ -60,4 +62,19 @@ return [
     'providers' => [
         // 'github',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Features
+    |--------------------------------------------------------------------------
+    |
+    | Some of Socialstreams's features are optional. You may disable the features
+    | by removing them from this array. You're free to only remove some of
+    | these features or you can even remove all of these if you need to.
+    |
+    */
+
+    'features' => [
+        // Features::createAccountOnFirstLogin(),
+    ]
 ];

--- a/src/Features.php
+++ b/src/Features.php
@@ -18,7 +18,7 @@ class Features
     /**
      * Determine if the application supports creating accounts
      * when logging in for the first time via a provider.
-     * 
+     *
      * @return bool
      */
     public static function createsAccountsOnFirstLogin()

--- a/src/Features.php
+++ b/src/Features.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JoelButcher\Socialstream;
+
+class Features
+{
+    /**
+     * Determine if the given feature is enabled.
+     *
+     * @param  string  $feature
+     * @return bool
+     */
+    public static function enabled(string $feature)
+    {
+        return in_array($feature, config('socialstream.features', []));
+    }
+
+    /**
+     * Determine if the application supports creating accounts
+     * when logging in for the first time via a provider.
+     * 
+     * @return bool
+     */
+    public static function createsAccountsOnFirstLogin()
+    {
+        return static::enabled(static::createAccountOnFirstLogin());
+    }
+
+    /**
+     * Enable the create account on first login feature.
+     *
+     * @return string
+     */
+    public static function createAccountOnFirstLogin()
+    {
+        return 'create-account-on-first-login';
+    }
+}

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
+use JoelButcher\Socialstream\Features;
 use JoelButcher\Socialstream\Socialstream;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Socialite\Facades\Socialite;
@@ -72,7 +73,7 @@ class OAuthController extends Controller
      */
     public function redirectToProvider(Request $request, string $provider, GeneratesProviderRedirect $generator)
     {
-        session()->put('url.previous', back()->getTargetUrl());
+        session()->put('socialstream.previous_url', back()->getTargetUrl());
 
         return $generator->generate($provider);
     }
@@ -122,7 +123,7 @@ class OAuthController extends Controller
         }
 
         // Registration...
-        if (session()->get('url.previous') === route('register')) {
+        if (session()->get('socialstream.previous_url') === route('register')) {
             if ($account) {
                 return redirect()->route('register')->withErrors(
                     __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider])
@@ -135,7 +136,7 @@ class OAuthController extends Controller
                 );
             }
 
-            if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first()) {
+            if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->exists()) {
                 return redirect()->route('register')->withErrors(
                     __('An account with that email address already exists. Please login to connect your :Provider account.', ['provider' => $provider])
                 );
@@ -148,12 +149,16 @@ class OAuthController extends Controller
             return redirect(config('fortify.home'));
         }
 
-        if (! $account) {
+        if (! Features::createsAccountsOnFirstLogin() && !$account) {
             return redirect()->route('login')->withErrors(
                 __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
             );
         }
 
+        if (Features::createsAccountsOnFirstLogin() && !$account) {
+            $user = $this->createsUser->create($provider, $providerAccount);
+        }
+        
         $this->guard->login($account->user, config('socialstream.remember'));
 
         $account->user->forceFill([

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -56,7 +56,7 @@ class Socialstream
 
     /**
      * Find a connected account instance fot a given provider and provider ID.
-     * 
+     *
      * @param  string  $provider
      * @param  string  $providerId
      * @return mixed


### PR DESCRIPTION
This PR allows developers to choose whether or not user create an account from the login screen without having to go to `/register`.

This PR was inspired by #49, a great feature suggestion from @luiyongsheng. I was originally going to merge the branch in, but was conscious of adding another config item for developers to worry about. This PR resolves that worry by following the "features" pattern found in Laravel Jetstream and Fortify, becoming instantly familiar.

To enable the features simply add the following to your `socialstream.php` config file:

```php
'features' => [
    \JoelButcher\Socialstream\Features::createAccountOnFirstLogin(),
]
```