### PR TITLE
Update token column length to recommended length by Linkedin

### DIFF
--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -23,7 +23,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('email')->nullable();
             $table->string('telephone')->nullable();
             $table->string('avatar_path')->nullable();
-            $table->string('token');
+            $table->string('token', 1000);
             $table->string('secret')->nullable(); // OAuth1
             $table->string('refresh_token')->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2

--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -25,7 +25,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('avatar_path')->nullable();
             $table->string('token', 1000);
             $table->string('secret')->nullable(); // OAuth1
-            $table->string('refresh_token')->nullable(); // OAuth2
+            $table->string('refresh_token', 1000)->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2
             $table->timestamps();
         });


### PR DESCRIPTION
According to LinkedIn docs  https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow#access-token-response

> The length of access tokens is ~500 characters. We recommend that you plan for your application to handle tokens with length of at least 1000 characters in order to accommodate any future expansion plans. This applies to both access tokens and refresh tokens.


The current migration will fail when trying to connect a LinkedIn account due to the default size for string fields.