### PR TITLE
[3.x] Add indexes to the migration files

### DIFF
--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -28,6 +28,9 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('refresh_token', 1000)->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2
             $table->timestamps();
+
+            $table->index(['user_id', 'id']);
+            $table->index(['provider', 'provider_id']);
         });
     }
 


### PR DESCRIPTION
Besides the `->foreignId('user_id')`, it seems like the table does not have built-in indexes for the following 2 queries:

```php
DB::table('connected_accounts')
    ->where('user_id', Auth::user()->getAuthIdentifier())
    ->where('id', $accountId)
    ->delete();
```

```php
static::newConnectedAccountModel()
    ->where('provider', $provider)
    ->where('provider_id', $providerId)
    ->first();
```