### PR TITLE
[3.x] Removed @click.native

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -32,7 +32,7 @@
                                         Use Avatar as Profile Photo
                                     </button>
 
-                                    <jet-danger-button @click.native="confirmRemove(getAccountForProvider(provider).id)" v-if="$page.props.socialstream.connectedAccounts.length > 1 || $page.props.socialstream.hasPassword">
+                                    <jet-danger-button @click="confirmRemove(getAccountForProvider(provider).id)" v-if="$page.props.socialstream.connectedAccounts.length > 1 || $page.props.socialstream.hasPassword">
                                         Remove
                                     </jet-danger-button>
                                 </div>
@@ -67,12 +67,12 @@
                 </template>
 
                 <template #footer>
-                    <jet-secondary-button @click.native="confirmingRemove = false">
+                    <jet-secondary-button @click="confirmingRemove = false">
                         Nevermind
                     </jet-secondary-button>
 
                     <jet-button class="ml-2"
-                                @click.native="removeConnectedAccount(accountId)"
+                                @click="removeConnectedAccount(accountId)"
                                 :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
                         Remove Connected Account
                     </jet-button>


### PR DESCRIPTION
It seems like Jetstream moved on over `.native` in Vue 3: https://github.com/laravel/jetstream/pull/689/commits/5e3cf0c48418f19b5a74dbdadbdab62a8b47d52f