### PR TITLE
[3.x] Show "Use Avatar as Profile Photo" button in the correct case

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -27,7 +27,7 @@
                             <template v-if="hasAccountForProvider(provider)">
                                 <div class="flex items-center space-x-6">
                                     <button
-                                        v-if="$page.props.jetstream.managesProfilePhotos"
+                                        v-if="$page.props.jetstream.managesProfilePhotos && getAccountForProvider(provider).avatar_path"
                                         @click="setProfilePhoto(getAccountForProvider(provider).id)"
                                         class="cursor-pointer ml-6 text-sm text-gray-500 focus:outline-none">
                                         Use Avatar as Profile Photo

--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -27,6 +27,7 @@
                             <template v-if="hasAccountForProvider(provider)">
                                 <div class="flex items-center space-x-6">
                                     <button
+                                        v-if="$page.props.jetstream.managesProfilePhotos"
                                         @click="setProfilePhoto(getAccountForProvider(provider).id)"
                                         class="cursor-pointer ml-6 text-sm text-gray-500 focus:outline-none">
                                         Use Avatar as Profile Photo
@@ -39,17 +40,9 @@
                             </template>
 
                             <template v-else>
-                                <div class="flex items-center space-x-6">
-                                    <button
-                                        @click="setProfilePhoto(getAccountForProvider(provider).id)"
-                                        class="cursor-pointer ml-6 text-sm text-gray-500 focus:outline-none">
-                                        Use Avatar as Profile Photo
-                                    </button>
-
-                                    <action-link :href="route('oauth.redirect', { provider })">
-                                        Connect
-                                    </action-link>
-                                </div>
+                                <action-link :href="route('oauth.redirect', { provider })">
+                                    Connect
+                                </action-link>
                             </template>
                         </template>
                     </connected-account>

--- a/stubs/livewire/resources/views/profile/connected-accounts-form.blade.php
+++ b/stubs/livewire/resources/views/profile/connected-accounts-form.blade.php
@@ -31,7 +31,7 @@
                     <x-slot name="action">
                         @if (! is_null($account))
                             <div class="flex items-center space-x-6">
-                                @if (! is_null($account->avatar_path))
+                                @if (Laravel\Jetstream\Jetstream::managesProfilePhotos() && ! is_null($account->avatar_path))
                                     <button class="cursor-pointer ml-6 text-sm text-gray-500 focus:outline-none" wire:click="setAvatarAsProfilePhoto({{ $account->id }})">
                                         {{ __('Use Avatar as Profile Photo') }}
                                     </button>


### PR DESCRIPTION
- Do not show the button when the provider account is currently not connected. (Currently showing on Inertia Stack)
- Do not show the button if the profile photo is disabled on Jetstream.