### PR TITLE
[3.x] Use HandleInvalidState contract in OAuthController instead of hard-coded concrete

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -2,7 +2,6 @@
 
 namespace JoelButcher\Socialstream\Http\Controllers;
 
-use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -10,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
+use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use JoelButcher\Socialstream\Contracts\ResolvesSocialiteUsers;
 use JoelButcher\Socialstream\Contracts\UpdatesConnectedAccounts;
 use JoelButcher\Socialstream\Features;

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -2,7 +2,7 @@
 
 namespace JoelButcher\Socialstream\Http\Controllers;
 
-use App\Actions\Socialstream\HandleInvalidState;
+use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -67,7 +67,7 @@ class OAuthController extends Controller
         CreatesUserFromProvider $createsUser,
         CreatesConnectedAccounts $createsConnectedAccounts,
         UpdatesConnectedAccounts $updatesConnectedAccounts,
-        HandleInvalidState $invalidStateHandler
+        HandlesInvalidState $invalidStateHandler
     ) {
         $this->guard = $guard;
         $this->createsUser = $createsUser;


### PR DESCRIPTION
Fixed the  :
Getting **No such file or directory error after moving HandleInvalidState.php** to other location]

We used App\Actions\Socialstream\HandleInvalidState directly in the OAuthcontroller.php . So if we move to HandleInvalidState to other location. It will throw an error.

closes #127 
