### PR TITLE
Increase Token Length to support Laravel Passport

### DIFF
--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -23,9 +23,9 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('email')->nullable();
             $table->string('telephone')->nullable();
             $table->string('avatar_path')->nullable();
-            $table->string('token', 1000);
+            $table->string('token', 1071);
             $table->string('secret')->nullable(); // OAuth1
-            $table->string('refresh_token', 1000)->nullable(); // OAuth2
+            $table->string('refresh_token', 1071)->nullable(); // OAuth2
             $table->dateTime('expires_at')->nullable(); // OAuth2
             $table->timestamps();
 


### PR DESCRIPTION
Laravel Passport token are *long* by default. Increasing the allowed token size in socialstream's migration files by 71 characters will allow users to implement socialstream with [SocialiteProviders/Laravel-Passport](https://socialiteproviders.com/Laravel-Passport).

