### PR TITLE
Fix profile photos that return long urls

### DIFF
--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -22,7 +22,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('nickname')->nullable();
             $table->string('email')->nullable();
             $table->string('telephone')->nullable();
-            $table->string('avatar_path', 1000)->nullable();
+            $table->string('avatar_path')->nullable();
             $table->string('token', 1000);
             $table->string('secret')->nullable(); // OAuth1
             $table->string('refresh_token', 1000)->nullable(); // OAuth2

--- a/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
+++ b/database/migrations/2020_12_22_000000_create_connected_accounts_table.php
@@ -22,7 +22,7 @@ class CreateConnectedAccountsTable extends Migration
             $table->string('nickname')->nullable();
             $table->string('email')->nullable();
             $table->string('telephone')->nullable();
-            $table->string('avatar_path')->nullable();
+            $table->string('avatar_path', 1000)->nullable();
             $table->string('token', 1000);
             $table->string('secret')->nullable(); // OAuth1
             $table->string('refresh_token', 1000)->nullable(); // OAuth2

--- a/src/SetsProfilePhotoFromUrl.php
+++ b/src/SetsProfilePhotoFromUrl.php
@@ -3,6 +3,7 @@
 namespace JoelButcher\Socialstream;
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
 
 trait SetsProfilePhotoFromUrl
 {
@@ -15,7 +16,7 @@ trait SetsProfilePhotoFromUrl
     public function setProfilePhotoFromUrl(string $url)
     {
         $name = pathinfo($url)['basename'];
-        file_put_contents($file = '/tmp/'.$name, file_get_contents($url));
+        file_put_contents($file = '/tmp/'.Str::uuid()->toString(), file_get_contents($url));
         $this->updateProfilePhoto(new UploadedFile($file, $name));
     }
 }


### PR DESCRIPTION
Fix errors for images returned by OAuth2 that have too long of a URL. Every google account I tested with returns a URL over the max input for the column and what is supported by default with file_put_contents(). For reference, my GSuite account profile image URL returned was 821 characters long. To fix this I:

Increased the avatar_path length to 1000
Replaced the temporary filename with UUID