### PR TITLE
[FIX] - Add conditional on empty connected account

### DIFF
--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -60,11 +60,7 @@ trait HasConnectedAccounts
      */
     public function ownsConnectedAccount($connectedAccount)
     {
-        if(empty($connectedAccount->user_id)) {
-            return false;
-        }
-
-        return $this->id == $connectedAccount->user_id;
+        return $this->id == optional($connectedAccount)->user_id;
     }
 
     /**

--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -60,6 +60,10 @@ trait HasConnectedAccounts
      */
     public function ownsConnectedAccount($connectedAccount)
     {
+        if(empty($connectedAccount->user_id)) {
+            return false;
+        }
+
         return $this->id == $connectedAccount->user_id;
     }
 


### PR DESCRIPTION
I was getting the following exception when getting connected accounts for users which were seeded and did not have any connected accounts:

_Error Trying to get property 'user_id' of non-object_ 

I've included a conditional to check whether there is a connected account which fixes this for me.