### PR TITLE
[3.x] Fix GitHub nomenclature

### DIFF
--- a/stubs/inertia/resources/js/Socialstream/Providers.vue
+++ b/stubs/inertia/resources/js/Socialstream/Providers.vue
@@ -29,7 +29,7 @@
 
             <a v-if="$page.props.socialstream.providers.includes('github')" :href="route('oauth.redirect', 'github')">
                 <github-icon class="h-6 w-6 mx-2" />
-                <span class="sr-only">Github</span>
+                <span class="sr-only">GitHub</span>
             </a>
 
             <a v-if="$page.props.socialstream.providers.includes('gitlab')" :href="route('oauth.redirect', 'gitlab')">

--- a/stubs/livewire/resources/views/components/socialstream-providers.blade.php
+++ b/stubs/livewire/resources/views/components/socialstream-providers.blade.php
@@ -36,7 +36,7 @@
     @if (JoelButcher\Socialstream\Socialstream::hasGithubSupport())
         <a href="{{ route('oauth.redirect', ['provider' => JoelButcher\Socialstream\Providers::github()]) }}">
             <x-github-icon class="h-6 w-6 mx-2" />
-            <span class="sr-only">Github</span>
+            <span class="sr-only">GitHub</span>
         </a>
     @endif
 


### PR DESCRIPTION
Writes GitHub with capital letters for the H