### PR TITLE
[3.x] Fix missing title on AppLayout component

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/Show.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/Show.vue
@@ -1,5 +1,5 @@
 <template>
-    <app-layout>
+    <app-layout title="Profile">
         <template #header>
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
                 Profile


### PR DESCRIPTION
Noticed a missing title on the Inertia Profile Show component, which is present in Laravel Jetstream with it's initial Inertia scaffolding.