### PR TITLE
[3.x] Fix SetsProfilePhotoFromUrl on non-UNIX systems

### DIFF
--- a/src/SetsProfilePhotoFromUrl.php
+++ b/src/SetsProfilePhotoFromUrl.php
@@ -16,7 +16,7 @@ trait SetsProfilePhotoFromUrl
     public function setProfilePhotoFromUrl(string $url)
     {
         $name = pathinfo($url)['basename'];
-        file_put_contents($file = '/tmp/'.Str::uuid()->toString(), file_get_contents($url));
+        file_put_contents($file = implode('/', [rtrim(sys_get_temp_dir(), '/'), ltrim(Str::uuid()->toString(), '/')]), file_get_contents($url));
         $this->updateProfilePhoto(new UploadedFile($file, $name));
     }
 }


### PR DESCRIPTION
This trait does not work under a Windows operating system, as the absolute /tmp path is not valid. This implementation uses [sys_get_temp_dir()](https://www.php.net/manual/en/function.sys-get-temp-dir.php) to get the appropriate OS specific temporary directory. This function is noted to not always include a trailing slash, so implode and ltrim is used here to connect the generated filename to the path.

This fixes Windows support for this trait. Tested with a third party Microsoft provider.