### PR TITLE
fix file_put_contents bug on windows

### DIFF
--- a/src/SetsProfilePhotoFromUrl.php
+++ b/src/SetsProfilePhotoFromUrl.php
@@ -16,7 +16,7 @@ trait SetsProfilePhotoFromUrl
     public function setProfilePhotoFromUrl(string $url)
     {
         $name = pathinfo($url)['basename'];
-        file_put_contents($file = '/tmp/'.Str::uuid()->toString(), file_get_contents($url));
+        file_put_contents($file = sys_get_temp_dir().Str::uuid()->toString(), file_get_contents($url));
         $this->updateProfilePhoto(new UploadedFile($file, $name));
     }
 }


### PR DESCRIPTION
While using a avatar on my windows dev machine, I faced this issue 
![img](https://i.imgur.com/W9C0FmH.png)

I've simply replaced '/tmp/' with php's `sys_get_temp_dir`-function, IMHO the correct way to set the tmp path 😄 