### PR TITLE
[3.x] Prevent multiple users connect the same social account 

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -119,7 +119,7 @@ class OAuthController extends Controller
         }
 
         // Registration...
-        if (FortifyFeatures::enabled(FortifyFeatures::registration()) && session()->get('socialstream.previous_url') === route('register')) {
+        if (FortifyFeatures::enabled(FortifyFeatures::registration()) && session()->get('socialstream.previous_url') === route('register') && ! $account) {
             $user = Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
 
             if ($user) {


### PR DESCRIPTION
When user A registers and connects a social account, then updates his user email, they can register a new user account using the same social account.
The result is 2 users that has the same social account connected. 

When trying to login with that social account, it will login the first user (first connected account returned from the query)

By checking if there is no account found, and only then enter the registration block we can prevent that, and skip to login the correct user.