### PR TITLE
[3.x] Add dynamic method calls for custom providers

### DIFF
--- a/src/Providers.php
+++ b/src/Providers.php
@@ -63,7 +63,7 @@ class Providers
      *
      * @return bool
      */
-    public static function hasGoogleSupport(): bool
+    public static function hasGoogleSupport()
     {
         return static::enabled(static::google());
     }

--- a/tests/ProvidersTest.php
+++ b/tests/ProvidersTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace JoelButcher\Socialstream\Tests;
+
+use Illuminate\Support\Facades\Config;
+use JoelButcher\Socialstream\Providers;
+
+class ProvidersTest extends TestCase
+{
+    public function test_it_supports_bitbucket_provider()
+    {
+        Config::set('socialstream.providers', [Providers::bitbucket()]);
+
+        $this->assertTrue(Providers::hasBitbucketSupport());
+    }
+
+    public function test_it_supports_facebook_provider()
+    {
+        Config::set('socialstream.providers', [Providers::facebook()]);
+
+        $this->assertTrue(Providers::hasFacebookSupport());
+    }
+
+    public function test_it_supports_github_provider()
+    {
+        Config::set('socialstream.providers', [Providers::github()]);
+
+        $this->assertTrue(Providers::hasGithubSupport());
+    }
+
+    public function test_it_supports_gitlab_provider()
+    {
+        Config::set('socialstream.providers', [Providers::gitlab()]);
+
+        $this->assertTrue(Providers::hasGitlabSupport());
+    }
+
+    public function test_it_supports_google_provider()
+    {
+        Config::set('socialstream.providers', [Providers::google()]);
+
+        $this->assertTrue(Providers::hasGoogleSupport());
+    }
+
+    public function test_it_supports_linked_in_provider()
+    {
+        Config::set('socialstream.providers', [Providers::linkedin()]);
+
+        $this->assertTrue(Providers::hasLinkedInSupport());
+    }
+
+    public function test_it_supports_twitter_provider()
+    {
+        Config::set('socialstream.providers', [Providers::twitter()]);
+
+        $this->assertTrue(Providers::hasTwitterSupport());
+    }
+
+    public function test_it_supports_custom_providers()
+    {
+        Config::set('socialstream.providers', ['my-custom-provider']);
+
+        $this->assertTrue(Providers::enabled('my-custom-provider'));
+    }
+
+    public function test_it_supports_dynamic_calls_for_custom_providers()
+    {
+        Config::set('socialstream.providers', ['a-custom-provider', 'another-provider', 'and-another']);
+
+        $this->assertTrue(Providers::hasACustomProviderSupport());
+        $this->assertTrue(Providers::hasAnotherProviderSupport());
+        $this->assertTrue(Providers::hasAndAnotherSupport());
+    }
+}


### PR DESCRIPTION
Partially resolves problems highlighted in #168. This PR adds some nice syntactic sugar on top of the `Providers` class.

Developer registering new providers (that don't come supported out-of-the-box), can now easily call check if their provider is enabled using a new `Providers::hasMyCustomProviderSupport` syntax.

Consider the following example:

```php
return [
    'providers' => [
        Providers::github(),
        Providers::facebook(),
        'apple' // Apple is not supported as a provider by Laravel Socialite and thus, not supported out-of-the-box by Socialstream
    ],
];
```

You now wish to update `socialstream-providers.blade.php` to cater for your condition. You can now call `Providers::hasAppleSupport()` to determine if the `apple` provider has been registered:

```blade
@if (\JoelButcher\Socialstream\Socialstream::hasAppleSupport())
    ...
@endif
```