### PR TITLE
Simple DocBlock improvement

### DIFF
--- a/src/Contracts/ResolvesSocialiteUsers.php
+++ b/src/Contracts/ResolvesSocialiteUsers.php
@@ -8,7 +8,7 @@ interface ResolvesSocialiteUsers
      * Resolve the user for a given provider.
      *
      * @param  string  $provider
-     * @return \Laravel\Socialite\AbstractUser
+     * @return \Laravel\Socialite\Contracts\User
      */
     public function resolve($provider);
 }

--- a/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
+++ b/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
@@ -12,7 +12,7 @@ class ResolveSocialiteUser implements ResolvesSocialiteUsers
      * Resolve the user for a given provider.
      *
      * @param  string  $provider
-     * @return \Laravel\Socialite\AbstractUser
+     * @return \Laravel\Socialite\Contracts\User
      */
     public function resolve($provider)
     {

--- a/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
+++ b/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
@@ -19,7 +19,7 @@ class ResolveSocialiteUser implements ResolvesSocialiteUsers
         $user = Socialite::driver($provider)->user();
 
         if (Socialstream::generatesMissingEmails()) {
-            $user->email = $user->getEmail() ?? ("{$user->id}@{$provider}" . config('app.domain'));
+            $user->email = $user->getEmail() ?? ("{$user->id}@{$provider}".config('app.domain'));
         }
 
         return $user;

--- a/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
+++ b/stubs/app/Actions/Socialstream/ResolveSocialiteUser.php
@@ -19,7 +19,7 @@ class ResolveSocialiteUser implements ResolvesSocialiteUsers
         $user = Socialite::driver($provider)->user();
 
         if (Socialstream::generatesMissingEmails()) {
-            $user->email = $user->getEmail() ?? "{$user->id}@{$provider}".config('app.domain');
+            $user->email = $user->getEmail() ?? ("{$user->id}@{$provider}" . config('app.domain'));
         }
 
         return $user;


### PR DESCRIPTION
This pull request improves the @return value from src/Contracts/ResolvesSocialiteUsers.php.

Currently the @return value for the following code is `Laravel\Socialite\Contracts\User`:
```php
$user = Socialite::driver($provider)->user();
```

This return type is less specific than the return type of the `resolve` from socialstream `Laravel\Socialite\AbstractUser`.

Throwing some warnings on static analysis such as Psalm (https://psalm.dev/129). This pull request do not impact in the code itself.