### PR TITLE
Fix 'Attempt to read property "avatar_path" on null' error on "Use Avatar as Profile Photo" action

### DIFF
--- a/src/Http/Controllers/Inertia/UpdateUserProfilePhotoController.php
+++ b/src/Http/Controllers/Inertia/UpdateUserProfilePhotoController.php
@@ -20,7 +20,7 @@ class UpdateUserProfilePhotoController extends Controller
             ->where('id', $request->id)
             ->first();
 
-        if (is_callable([$user, 'setProfilePhotoFromUrl']) && ! is_null($account->avatar_path)) {
+        if (is_callable([$user, 'setProfilePhotoFromUrl']) && isset($account->avatar_path)) {
             $user->setProfilePhotoFromUrl($account->avatar_path);
         }
 


### PR DESCRIPTION
If you make a PUT request to ```/user/profile-photo```, an ```ErrorException``` will be thrown if there is no account returned, which can happen if ``` $request->id``` is not provided or does not exist.

```
ErrorException: Attempt to read property "avatar_path" on null in file /var/www/html/vendor/joelbutcher/socialstream/src/Http/Controllers/Inertia/UpdateUserProfilePhotoController.php on line 23
```

Changing "! is_null()" to "isset()" will ensure that the variable exists and is not null.