### PR TITLE
Fix account removal for non-databse sessions

### DIFF
--- a/src/Http/Controllers/Inertia/RemoveConnectedAccountsController.php
+++ b/src/Http/Controllers/Inertia/RemoveConnectedAccountsController.php
@@ -31,10 +31,6 @@ class RemoveConnectedAccountsController extends Controller
      */
     public function removeConnectedAccount(Request $request, $id)
     {
-        if (config('session.driver') !== 'database') {
-            return;
-        }
-
         DB::table('connected_accounts')
             ->where('user_id', $request->user()->getKey())
             ->where('id', $id)


### PR DESCRIPTION
I recently discovered that removing an OAuth provider using the Redis session driver did not work. Going through the code I saw that only the database session driver is allowed to delete connected accounts.

I do not see a reason for this, so I am creating a PR to remove this check. If I am incorrect and there is a reason for this that I am not thinking of, is there a future plan to support deleting connected accounts using other drivers?