### PR TITLE
[3.x] Drop Laravel 8.x and PHP 7.3, 7.4 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', '8.1']
-        laravel: [8, 9]
-        exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
+        php: [ '8.0', 8.1 ]
+        laravel: [ 9 ]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -37,8 +32,50 @@ jobs:
 
       - name: Install dependencies
         run: |
-           composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
-           composer update --prefer-dist --no-interaction --no-progress
+          composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
+
+  stub-tests:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        stack: [ inertia, livewire ]
+
+    name: Test Stubs (${{ matrix.stack }})
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Setup Laravel
+        run: |
+          composer create-project laravel/laravel:^9 .
+          composer require laravel/jetstream:^2
+          rm -rf vendor/laravel/jetstream
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: 'vendor/laravel/jetstream'
+
+      - name: Install Jetstream
+        run: |
+          composer dump
+          php artisan jetstream:install ${{ matrix.stack }} --teams --api --verification
+          php artisan socialstream:install
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --verbose
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ":memory:"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Setup Laravel
         run: |
           composer create-project laravel/laravel:^9 .
-          composer require laravel/jetstream:^2
-          rm -rf vendor/laravel/jetstream
+          composer require joelbutcher/socialstream:^2
+          rm -rf vendor/joelbutcher/socialstream
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          path: 'vendor/laravel/jetstream'
+          path: 'vendor/joelbutcher/socialstream'
 
       - name: Install Jetstream & Socialstream
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           path: 'vendor/laravel/jetstream'
 
-      - name: Install Jetstream
+      - name: Install Jetstream & Socialstream
         run: |
           composer dump
           php artisan jetstream:install ${{ matrix.stack }} --teams --api --verification

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Laravel
         run: |
           composer create-project laravel/laravel:^9 .
-          composer require joelbutcher/socialstream:^2
+          composer require joelbutcher/socialstream:^3
           rm -rf vendor/joelbutcher/socialstream
       - name: Checkout code
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -28,17 +28,17 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "doctrine/dbal": "^2.9|^3.0",
-        "illuminate/support": "^8.0|^9.0",
-        "laravel/jetstream": "^2.7.0",
-        "laravel/socialite": "^5.0"
+        "php": "^8.0.2",
+        "doctrine/dbal": "^3.0",
+        "illuminate/support": "^9.21",
+        "laravel/jetstream": "^2.10.1",
+        "laravel/socialite": "^5.5.1"
     },
     "require-dev": {
         "inertiajs/inertia-laravel": "^0.5.2",
         "laravel/sanctum": "^2.7",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {


### PR DESCRIPTION
This PR updates Socialstream to drop support for Laravel 8.x and by extension, drop support for PHP 7.3 & 7.4.

Although the change is made in the repo, because Jetstream is a dependency and has already drop support for Laravel 8, up until now, this will have been reflected via composer's dependency management.