### PR TITLE
[3.x] Fix Twitter OAuth 2.0 redeirect URL generation links

### DIFF
--- a/stubs/inertia/resources/js/Socialstream/ConnectedAccount.vue
+++ b/stubs/inertia/resources/js/Socialstream/ConnectedAccount.vue
@@ -23,7 +23,7 @@ defineProps({
 
                 <FacebookIcon class="h-6 w-6 mr-2" v-if="provider === 'facebook'" />
                 <GoogleIcon class="h-6 w-6 mr-2" v-if="provider === 'google'" />
-                <TwitterIcon class="h-6 w-6 mr-2" v-if="provider === 'twitter'" />
+                <TwitterIcon class="h-6 w-6 mr-2" v-if="provider === 'twitter' || 'twitter-oauth-2'" />
                 <LinkedInIcon class="h-6 w-6 mr-2" v-if="provider === 'linkedin'" />
                 <GithubIcon class="h-6 w-6 mr-2" v-if="provider === 'github'" />
                 <GitLabIcon class="h-6 w-6 mr-2" v-if="provider === 'gitlab'" />
@@ -31,7 +31,7 @@ defineProps({
 
                 <div>
                     <div class="text-sm font-semibold text-gray-600">
-                        {{ provider.charAt(0).toUpperCase() + provider.slice(1) }}
+                        {{ provider === 'twitter-oauth-2' ? 'Twitter' : provider.charAt(0).toUpperCase() + provider.slice(1) }}
                     </div>
 
                     <div v-if="createdAt !== null" class="text-xs text-gray-500">

--- a/stubs/inertia/resources/js/Socialstream/Providers.vue
+++ b/stubs/inertia/resources/js/Socialstream/Providers.vue
@@ -1,57 +1,85 @@
 <script setup>
-    import FacebookIcon from './ProviderIcons/FacebookIcon.vue';
-    import GoogleIcon from './ProviderIcons/GoogleIcon.vue';
-    import TwitterIcon from './ProviderIcons/TwitterIcon.vue';
-    import LinkedInIcon from './ProviderIcons/LinkedInIcon.vue';
-    import GithubIcon from './ProviderIcons/GithubIcon.vue';
-    import GitLabIcon from './ProviderIcons/GitLabIcon.vue';
-    import BitbucketIcon from './ProviderIcons/BitbucketIcon.vue';
+import FacebookIcon from "./ProviderIcons/FacebookIcon.vue";
+import GoogleIcon from "./ProviderIcons/GoogleIcon.vue";
+import TwitterIcon from "./ProviderIcons/TwitterIcon.vue";
+import LinkedInIcon from "./ProviderIcons/LinkedInIcon.vue";
+import GithubIcon from "./ProviderIcons/GithubIcon.vue";
+import GitLabIcon from "./ProviderIcons/GitLabIcon.vue";
+import BitbucketIcon from "./ProviderIcons/BitbucketIcon.vue";
 </script>
 
 <template>
-    <div>
-        <div class="flex flex-row items-center justify-between py-4 text-gray-500">
-            <hr class="w-full mr-2">
-                Or
-            <hr class="w-full ml-2">
-        </div>
-
-        <div class="flex items-center justify-center">
-            <a v-if="$page.props.socialstream.providers.includes('facebook')" :href="route('oauth.redirect', 'facebook')">
-                <FacebookIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">Facebook</span>
-            </a>
-
-            <a v-if="$page.props.socialstream.providers.includes('google')" :href="route('oauth.redirect', 'google')" >
-                <GoogleIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">Google</span>
-            </a>
-
-            <a
-                v-if="$page.props.socialstream.providers.includes('twitter') || $page.props.socialstream.providers.includes('twitter-oauth-2')" :href="route('oauth.redirect', 'twitter')">
-                <TwitterIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">Twitter</span>
-            </a>
-
-            <a v-if="$page.props.socialstream.providers.includes('linkedin')" :href="route('oauth.redirect', 'linkedin')">
-                <LinkedInIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">LinkedIn</span>
-            </a>
-
-            <a v-if="$page.props.socialstream.providers.includes('github')" :href="route('oauth.redirect', 'github')">
-                <GithubIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">GitHub</span>
-            </a>
-
-            <a v-if="$page.props.socialstream.providers.includes('gitlab')" :href="route('oauth.redirect', 'gitlab')">
-                <GitLabIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">GitLab</span>
-            </a>
-
-            <a v-if="$page.props.socialstream.providers.includes('bitbucket')" :href="route('oauth.redirect', 'bitbucket')">
-                <BitbucketIcon class="h-6 w-6 mx-2" />
-                <span class="sr-only">BitBucket</span>
-            </a>
-        </div>
+  <div>
+    <div class="flex flex-row items-center justify-between py-4 text-gray-500">
+      <hr class="w-full mr-2" />
+      Or
+      <hr class="w-full ml-2" />
     </div>
+
+    <div class="flex items-center justify-center">
+      <a
+        v-if="$page.props.socialstream.providers.includes('facebook')"
+        :href="route('oauth.redirect', 'facebook')"
+      >
+        <FacebookIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">Facebook</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('google')"
+        :href="route('oauth.redirect', 'google')"
+      >
+        <GoogleIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">Google</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('twitter')"
+        :href="route('oauth.redirect', 'twitter')"
+      >
+        <TwitterIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">Twitter</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('twitter-oauth-2')"
+        :href="route('oauth.redirect', 'twitter-oauth-2')"
+      >
+        <TwitterIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">Twitter</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('linkedin')"
+        :href="route('oauth.redirect', 'linkedin')"
+      >
+        <LinkedInIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">LinkedIn</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('github')"
+        :href="route('oauth.redirect', 'github')"
+      >
+        <GithubIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">GitHub</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('gitlab')"
+        :href="route('oauth.redirect', 'gitlab')"
+      >
+        <GitLabIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">GitLab</span>
+      </a>
+
+      <a
+        v-if="$page.props.socialstream.providers.includes('bitbucket')"
+        :href="route('oauth.redirect', 'bitbucket')"
+      >
+        <BitbucketIcon class="h-6 w-6 mx-2" />
+        <span class="sr-only">BitBucket</span>
+      </a>
+    </div>
+  </div>
 </template>

--- a/stubs/livewire/resources/views/components/connected-account.blade.php
+++ b/stubs/livewire/resources/views/components/connected-account.blade.php
@@ -10,7 +10,7 @@
                 @case(JoelButcher\Socialstream\Providers::google())
                     <x-google-icon class="h-6 w-6 mr-2" />
                     @break
-                @case(JoelButcher\Socialstream\Providers::twitter())
+                @case(JoelButcher\Socialstream\Providers::twitter() || JoelButcher\Socialstream\Providers::twitterOAuth2())
                     <x-twitter-icon class="h-6 w-6 mr-2" />
                     @break
                 @case(JoelButcher\Socialstream\Providers::linkedin())

--- a/stubs/livewire/resources/views/components/socialstream-providers.blade.php
+++ b/stubs/livewire/resources/views/components/socialstream-providers.blade.php
@@ -19,8 +19,15 @@
         </a>
     @endif
 
-    @if (JoelButcher\Socialstream\Socialstream::hasTwitterSupport())
+    @if (JoelButcher\Socialstream\Socialstream::hasTwitterOAuth1Support())
         <a href="{{ route('oauth.redirect', ['provider' => JoelButcher\Socialstream\Providers::twitter()]) }}">
+            <x-twitter-icon class="h-6 w-6 mx-2" />
+            <span class="sr-only">Twitter</span>
+        </a>
+    @endif
+
+    @if (JoelButcher\Socialstream\Socialstream::hasTwitterOAuth2Support())
+        <a href="{{ route('oauth.redirect', ['provider' => JoelButcher\Socialstream\Providers::twitterOAuth2()]) }}">
             <x-twitter-icon class="h-6 w-6 mx-2" />
             <span class="sr-only">Twitter</span>
         </a>


### PR DESCRIPTION
Fixes following bugs with new Twitter oAuth2:

- Twitter Icon doesn't show in ConnectedAccount.vue if oAuth2
- Provider name now shows as 'Twitter' instead of "Twitter-oauth2" in ConnectedAccounts List
- Twitter oauth2 now links to the correct endpoint in Providers.vue

All changes apply for vue and livewire.