### PR TITLE
[3.x] Fix twitter icon bug in enabled providers in connected account form

### DIFF
--- a/stubs/inertia/resources/js/Components/ConnectedAccount.vue
+++ b/stubs/inertia/resources/js/Components/ConnectedAccount.vue
@@ -23,7 +23,7 @@ defineProps({
 
                 <FacebookIcon class="h-6 w-6 mr-2" v-if="provider === 'facebook'" />
                 <GoogleIcon class="h-6 w-6 mr-2" v-if="provider === 'google'" />
-                <TwitterIcon class="h-6 w-6 mr-2" v-if="provider === 'twitter' || 'twitter-oauth-2'" />
+                <TwitterIcon class="h-6 w-6 mr-2" v-if="['twitter', 'twitter-oauth-2'].includes(provider)" />
                 <LinkedInIcon class="h-6 w-6 mr-2" v-if="provider === 'linkedin'" />
                 <GithubIcon class="h-6 w-6 mr-2" v-if="provider === 'github'" />
                 <GitLabIcon class="h-6 w-6 mr-2" v-if="provider === 'gitlab'" />


### PR DESCRIPTION
This PR fixes an issue introduced by #208 whereby the twitter icon is shown next to the icon of any enabled provider in the `ConnectedAccount.vue` component:

<img width="840" alt="Screenshot 2022-08-17 at 22 01 52" src="https://user-images.githubusercontent.com/7163152/185242405-6dd09110-0c78-47fb-8f0e-f21a13505942.png">
