### PR TITLE
[3.x] Update readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,38 @@
-<p align="center"><img src="https://ik.imagekit.io/r6kac144kke/logo_tNST3_4jfkSh.png" width="450"></p>
+# Socialstream
 
-<p align="center">
-    <a href="https://github.com/joelbutcher/socialstream/actions">
-        <img src="https://github.com/joelbutcher/socialstream/workflows/tests/badge.svg" alt="Build Status">
-    </a>
-    <a href="https://packagist.org/packages/joelbutcher/socialstream">
-        <img src="https://img.shields.io/packagist/dt/joelbutcher/socialstream" alt="Total Downloads">
-    </a>
-    <a href="https://packagist.org/packages/joelbutcher/socialstream">
-        <img src="https://img.shields.io/packagist/v/joelbutcher/socialstream" alt="Latest Stable Version">
-    </a>
-    <a href="https://packagist.org/packages/joelbutcher/socialstream">
-        <img src="https://img.shields.io/packagist/l/joelbutcher/socialstream" alt="License">
-    </a>
-</p>
+<a href="https://github.com/joelbutcher/socialstream/actions">
+    <img src="https://github.com/joelbutcher/socialstream/workflows/tests/badge.svg" alt="Build Status">
+</a>
+<a href="https://packagist.org/packages/joelbutcher/socialstream">
+    <img src="https://img.shields.io/packagist/dt/joelbutcher/socialstream" alt="Total Downloads">
+</a>
+<a href="https://packagist.org/packages/joelbutcher/socialstream">
+    <img src="https://img.shields.io/packagist/v/joelbutcher/socialstream" alt="Latest Stable Version">
+</a>
+<a href="https://packagist.org/packages/joelbutcher/socialstream">
+    <img src="https://img.shields.io/packagist/l/joelbutcher/socialstream" alt="License">
+</a>
 
 ## Introduction
 
 Socialstream is a third-party package for [Laravel Jetstream](https://github.com/laravel/jetstream). It replaces the published authentication and profile scaffolding provided by Laravel Jetstream, with scaffolding that has support for [Laravel Socialite](https://laravel.com/docs/8.x/socialite).
 
-If you are unfamiliar with Laravel Socialite, it is strongly advised that you take a look at the [official documentation](https://laravel.com/docs/8.x/socialite). 
+If you are unfamiliar with Laravel Socialite, it is strongly advised that you take a look at the [official documentation](https://laravel.com/docs/socialite).
+
+> :warning: Socialstream, like Jetstream, should only be installed on NEW applications, installing Socialstream into an existing application will break your applications functionality. It is strongly advised against installing this package within an existing applications.
 
 ## Official Documentation
 
-Documentation for Socialstream can be found on the [documentation site](https://docs.socialstream.dev).
+Documentation for Socialstream can be found on the [Socialstream website](https://docs.socialstream.dev).
 
 ## Contributing
 
 Thank you for considering contributing to Socialstream! You can read the contribution guide [here](.github/CONTRIBUTING.md).
 
-## Credits and Maintainers
-
-Socialstream is developed and maintained by [Joel Butcher](https://joelbutcher.co.uk) and has a strong community of contributors helping make it the best package for integrating Socialite into your application. You can view all contributers [here](https://github.com/joelbutcher/socialstream/graphs/contributors)
-
 ## Code of Conduct
 
-In order to ensure that the community is welcoming to all, please review and abide by the [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+In order to ensure that the Laravel development community is welcoming to all, please review and abide by the [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+
 
 ## License
 


### PR DESCRIPTION
This PR updates the `README.md` document to point developers to the [new documentation site](https://docs.socialstream.dev) in Gitbooks