### PR TITLE
Update Socialstream.php

### DIFF
--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -159,7 +159,7 @@ class Socialstream
      */
     public static function hasTwitterOAuth1Support()
     {
-        return Providers::hasTwitterOAuth2Support();
+        return Providers::hasTwitterOAuth1Support();
     }
 
     /**


### PR DESCRIPTION
Twitter Oauth 1.0 doesn't work because when it checks it return Oauth 2.0 support.