### PR TITLE
[3.x] Support linking connected accounts via the login flow

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -125,7 +125,14 @@ class OAuthController extends Controller
         }
 
         // Registration...
-        if (FortifyFeatures::enabled(FortifyFeatures::registration()) && session()->get('socialstream.previous_url') === route('register') && ! $account) {
+        $previousUrl = session()->get('socialstream.previous_url');
+        if (
+            FortifyFeatures::enabled(FortifyFeatures::registration()) && ! $account &&
+            (
+                $previousUrl === route('register') ||
+                (Features::hasCreateAccountOnFirstLoginFeatures() && $previousUrl === route('login'))
+            )
+        ) {
             $user = Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
 
             if ($user) {


### PR DESCRIPTION
Currently you can enable automatic new-user registration via the login flow, and you can enable linking an existing user to a new connected account via the registration flow, but you can't link an existing user to a new connected account via the login flow - this PR adds that if you are using `hasCreateAccountOnFirstLoginFeatures`.