### PR TITLE
Use `authIdentifier` in relationships

### DIFF
--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -24,7 +24,7 @@ abstract class ConnectedAccount extends Model
      */
     public function user()
     {
-        return $this->belongsTo(Jetstream::userModel(), 'user_id');
+        return $this->belongsTo(Jetstream::userModel(), 'user_id', (Jetstream::newUserModel())->getAuthIdentifierName());
     }
 
     /**

--- a/src/HasConnectedAccounts.php
+++ b/src/HasConnectedAccounts.php
@@ -115,6 +115,6 @@ trait HasConnectedAccounts
      */
     public function connectedAccounts()
     {
-        return $this->hasMany(Socialstream::connectedAccountModel(), 'user_id');
+        return $this->hasMany(Socialstream::connectedAccountModel(), 'user_id', $this->getAuthIdentifierName());
     }
 }


### PR DESCRIPTION
The `authIdentifier` is used to retrieve connected accounts, which will cause an error if the `authIdentifier` has been changed, to for instance something like `uuid`. 

```php   
/**
     * Set the providers avatar url as the users profile photo url.
     *
     * @param  mixed  $accountId
     */
    public function setAvatarAsProfilePhoto($accountId)
    {
        $account = Auth::user()->connectedAccounts
            ->where('user_id', ($user = Auth::user())->getAuthIdentifier())
            ->where('id', $accountId)
            ->first();

        if (is_callable([$user, 'setProfilePhotoFromUrl']) && ! is_null($account->avatar_path)) {
            $user->setProfilePhotoFromUrl($account->avatar_path);
        }

        return redirect()->route('profile.show');
    }
```


This PR avoids users of the package having to override relationship methods if they change the `authIdentifier`. 

Migrations are published anyway so there's no need to change anything there, putting application logic into a migration file is probably not a good idea.

