### PR TITLE
Adding computed inertiaProps to fix console errors

### DIFF
--- a/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
+++ b/stubs/inertia/resources/js/Pages/Profile/ConnectedAccountsForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useForm, usePage } from '@inertiajs/vue3'
 import ActionLink from '@/Components/ActionLink.vue';
 import ActionSection from '@/Components/ActionSection.vue';
@@ -13,7 +13,7 @@ const confirmingRemove = ref(false);
 
 const accountId = ref(null);
 
-const inertiaProps = usePage().props;
+const inertiaProps = computed(() => usePage().props);
 
 const form = useForm({
     _method: 'DELETE',


### PR DESCRIPTION
When installing the latest update with Ineria v1 and Vue3 you get the following error when loading the profile page in Jetstream.

<img width="755" alt="Screen Shot 2023-01-31 at 6 26 51 PM" src="https://user-images.githubusercontent.com/44442621/215930381-1f60ab61-9f71-4a3f-b8b3-72a057c545ec.png">

This PR makes the inertiaProps inside of the **ConnectedAccountsForm.vue** form to have computed data so that the values will show under **inertiaProps.value**.