### PR TITLE
jetstream v3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^8.0.2",
         "doctrine/dbal": "^3.0",
         "illuminate/support": "^9.21|^10.0",
-        "laravel/jetstream": "^2.15|^2.16",
+        "laravel/jetstream": "^2.15|^2.16|^3.0",
         "laravel/socialite": "^5.5|^5.6"
     },
     "require-dev": {


### PR DESCRIPTION
Nevermind, this PR won't work. I think Socialstream will need to be a 4.0 version to support jetstream because you can no longer do {{ $page.props.user.name }} - it has changed to {{ $page.props.**auth**.user.name }} {{ $page.props.**auth**.user.email }} etc...

A bigger PR would be required.