### PR TITLE
[4.x] Allow customisation of authentication logic

### DIFF
--- a/src/Actions/Auth/AuthenticateOauthCallback.php
+++ b/src/Actions/Auth/AuthenticateOauthCallback.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace JoelButcher\Socialstream\Actions\Auth;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\MessageBag;
+use JoelButcher\Socialstream\ConnectedAccount;
+use JoelButcher\Socialstream\Contracts\AuthenticatesOauthCallback;
+use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
+use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
+use JoelButcher\Socialstream\Contracts\UpdatesConnectedAccounts;
+use JoelButcher\Socialstream\Features;
+use JoelButcher\Socialstream\Socialstream;
+use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Features as FortifyFeatures;
+use Laravel\Jetstream\Jetstream;
+use Laravel\Socialite\Contracts\User as ProviderUser;
+
+class AuthenticateOauthCallback implements AuthenticatesOauthCallback
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        protected StatefulGuard $guard,
+        protected CreatesUserFromProvider $createsUser,
+        protected CreatesConnectedAccounts $createsConnectedAccounts,
+        protected UpdatesConnectedAccounts $updatesConnectedAccounts
+    ) {
+        //
+    }
+
+    public function authenticate(string $provider, ProviderUser $providerAccount): Response|RedirectResponse|LoginResponse
+    {
+        $account = Socialstream::findConnectedAccountForProviderAndId($provider, $providerAccount->getId());
+
+        // Authenticated...
+        if (! is_null($user = Auth::user())) {
+            return $this->alreadyAuthenticated($user, $account, $provider, $providerAccount);
+        }
+
+        // Registration...
+        $previousUrl = session()->get('socialstream.previous_url');
+
+        if (
+            FortifyFeatures::enabled(FortifyFeatures::registration()) && ! $account &&
+            (
+                $previousUrl === route('register') ||
+                (Features::hasCreateAccountOnFirstLoginFeatures() && $previousUrl === route('login'))
+            )
+        ) {
+            $user = Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
+
+            if ($user) {
+                return $this->handleUserAlreadyRegistered($user, $account, $provider, $providerAccount);
+            }
+
+            return $this->register($provider, $providerAccount);
+        }
+
+        if (! Features::hasCreateAccountOnFirstLoginFeatures() && ! $account) {
+            $messageBag = new MessageBag;
+            $messageBag->add(
+                'socialstream',
+                __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
+            );
+
+            return redirect()->route('login')->withErrors(
+                $messageBag
+            );
+        }
+
+        if (Features::hasCreateAccountOnFirstLoginFeatures() && ! $account) {
+            if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->exists()) {
+                $messageBag = new MessageBag;
+                $messageBag->add(
+                    'socialstream',
+                    __('An account with that email address already exists. Please login to connect your :Provider account.', ['provider' => $provider])
+                );
+
+                return redirect()->route('login')->withErrors(
+                    $messageBag
+                );
+            }
+
+            $user = $this->createsUser->create($provider, $providerAccount);
+
+            return $this->login($user);
+        }
+
+        $user = $account->user;
+
+        $this->updatesConnectedAccounts->update($user, $account, $provider, $providerAccount);
+
+        $user->forceFill([
+            'current_connected_account_id' => $account->id,
+        ])->save();
+
+        return $this->login($user);
+    }
+
+    /**
+     * Handle connection of accounts for an already authenticated user.
+     */
+    protected function alreadyAuthenticated(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse
+    {
+        if ($account && $account->user_id !== $user->id) {
+            return redirect()->route('profile.show')->dangerBanner(
+                __('This :Provider sign in account is already associated with another user. Please try a different account.', ['provider' => $provider]),
+            );
+        }
+
+        if (! $account) {
+            $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
+
+            return redirect()->route('profile.show')->banner(
+                __('You have successfully connected :Provider to your account.', ['provider' => $provider])
+            );
+        }
+
+        return redirect()->route('profile.show')->dangerBanner(
+            __('This :Provider sign in account is already associated with your user.', ['provider' => $provider]),
+        );
+    }
+
+    /**
+     * Handle when a user is already registered.
+     */
+    protected function handleUserAlreadyRegistered(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
+    {
+        if (Features::hasLoginOnRegistrationFeatures()) {
+
+            // The user exists, but they're not registered with the given provider.
+            if (! $account) {
+                $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
+            }
+
+            return $this->login($user);
+        }
+
+        $messageBag = new MessageBag;
+        $messageBag->add('socialstream', __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider]));
+
+        return redirect()->route('register')->withErrors($messageBag);
+    }
+
+    /**
+     * Handle the registration of a new user.
+     */
+    protected function register(string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
+    {
+        if (! $providerAccount->getEmail()) {
+            $messageBag = new MessageBag;
+            $messageBag->add(
+                'socialstream',
+                __('No email address is associated with this :Provider account. Please try a different account.', ['provider' => $provider])
+            );
+
+            return redirect()->route('register')->withErrors($messageBag);
+        }
+
+        if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->exists()) {
+            $messageBag = new MessageBag;
+            $messageBag->add(
+                'socialstream',
+                __('An account with that email address already exists. Please login to connect your :Provider account.', ['provider' => $provider])
+            );
+
+            return redirect()->route('register')->withErrors($messageBag);
+        }
+
+        $user = $this->createsUser->create($provider, $providerAccount);
+
+        return $this->login($user);
+    }
+
+    /**
+     * Authenticate the given user and return a login response.
+     */
+    protected function login(Authenticatable $user): LoginResponse
+    {
+        $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
+
+        return app(LoginResponse::class);
+    }
+}

--- a/src/Actions/Auth/AuthenticateOauthCallback.php
+++ b/src/Actions/Auth/AuthenticateOauthCallback.php
@@ -56,7 +56,7 @@ class AuthenticateOauthCallback implements AuthenticatesOauthCallback
             $user = Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
 
             if ($user) {
-                return $this->handleUserAlreadyRegistered($user, $account, $provider, $providerAccount);
+                return $this->alreadyRegistered($user, $account, $provider, $providerAccount);
             }
 
             return $this->register($provider, $providerAccount);
@@ -130,7 +130,7 @@ class AuthenticateOauthCallback implements AuthenticatesOauthCallback
     /**
      * Handle when a user is already registered.
      */
-    protected function handleUserAlreadyRegistered(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
+    protected function alreadyRegistered(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
     {
         if (Features::hasLoginOnRegistrationFeatures()) {
 

--- a/src/Actions/Auth/HandleOauthCallbackErrors.php
+++ b/src/Actions/Auth/HandleOauthCallbackErrors.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace JoelButcher\Socialstream\Actions\Auth;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\MessageBag;
+use JoelButcher\Socialstream\Contracts\HandlesOauthCallbackErrors;
+use Laravel\Fortify\Features as FortifyFeatures;
+
+class HandleOauthCallbackErrors implements HandlesOauthCallbackErrors
+{
+    /**
+     * Handles the request if the "errors" key is present.
+     */
+    public function handle(Request $request): ?RedirectResponse
+    {
+        if (! $request->has('error')) {
+            return null;
+        }
+
+        $messageBag = new MessageBag;
+        $messageBag->add('socialstream', $request->get('error_description'));
+
+        return Auth::check()
+            ? redirect(config('fortify.home'))->dangerBanner($request->get('error_description'))
+            : redirect()->route(
+                FortifyFeatures::enabled(FortifyFeatures::registration()) ? 'register' : 'login'
+            )->withErrors($messageBag);
+    }
+}

--- a/src/Contracts/AuthenticatesOauthCallback.php
+++ b/src/Contracts/AuthenticatesOauthCallback.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace JoelButcher\Socialstream\Contracts;
+
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Socialite\Contracts\User;
+
+interface AuthenticatesOauthCallback
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        StatefulGuard $guard,
+        CreatesUserFromProvider $createsUser,
+        CreatesConnectedAccounts $createsConnectedAccounts,
+        UpdatesConnectedAccounts $updatesConnectedAccounts
+    );
+
+    /**
+     * Authenticates users returning from an OAuth flow.
+     */
+    public function authenticate(string $provider, User $providerAccount): Response|RedirectResponse|LoginResponse;
+}

--- a/src/Contracts/HandlesOauthCallbackErrors.php
+++ b/src/Contracts/HandlesOauthCallbackErrors.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JoelButcher\Socialstream\Contracts;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+interface HandlesOauthCallbackErrors
+{
+    /**
+     * Handles the request if the "errors" key is present.
+     */
+    public function handle(Request $request): ?RedirectResponse;
+}

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -2,27 +2,16 @@
 
 namespace JoelButcher\Socialstream\Http\Controllers;
 
-use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\MessageBag;
-use JoelButcher\Socialstream\ConnectedAccount;
-use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
-use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
+use JoelButcher\Socialstream\Contracts\AuthenticatesOauthCallback;
 use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
 use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
+use JoelButcher\Socialstream\Contracts\HandlesOauthCallbackErrors;
 use JoelButcher\Socialstream\Contracts\ResolvesSocialiteUsers;
-use JoelButcher\Socialstream\Contracts\UpdatesConnectedAccounts;
-use JoelButcher\Socialstream\Features;
-use JoelButcher\Socialstream\Socialstream;
 use Laravel\Fortify\Contracts\LoginResponse;
-use Laravel\Fortify\Features as FortifyFeatures;
-use Laravel\Jetstream\Jetstream;
-use Laravel\Socialite\Contracts\User as ProviderUser;
 use Laravel\Socialite\Two\InvalidStateException;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 
@@ -32,10 +21,9 @@ class OAuthController extends Controller
      * Create a new controller instance.
      */
     public function __construct(
-        protected StatefulGuard $guard,
-        protected CreatesUserFromProvider $createsUser,
-        protected CreatesConnectedAccounts $createsConnectedAccounts,
-        protected UpdatesConnectedAccounts $updatesConnectedAccounts,
+        protected HandlesOauthCallbackErrors $errorHandler,
+        protected ResolvesSocialiteUsers $userResolver,
+        protected AuthenticatesOauthCallback $authenticator,
         protected HandlesInvalidState $invalidStateHandler
     ) {
         //
@@ -54,174 +42,20 @@ class OAuthController extends Controller
     /**
      * Attempt to log the user in via the provider user returned from Socialite.
      */
-    public function handleProviderCallback(Request $request, string $provider, ResolvesSocialiteUsers $resolver): Response|RedirectResponse|LoginResponse
+    public function handleProviderCallback(Request $request, string $provider): Response|RedirectResponse|LoginResponse
     {
-        if ($request->has('error')) {
-            $messageBag = new MessageBag;
-            $messageBag->add('socialstream', $request->error_description);
+        $redirect = $this->errorHandler->handle($request);
 
-            return Auth::check()
-                ? redirect(config('fortify.home'))->dangerBanner($request->error_description)
-                : redirect()->route(
-                    FortifyFeatures::enabled(FortifyFeatures::registration()) ? 'register' : 'login'
-                )->withErrors($messageBag);
+        if ($redirect instanceof RedirectResponse) {
+            return $redirect;
         }
 
         try {
-            $providerAccount = $resolver->resolve($provider);
+            $providerAccount = $this->userResolver->resolve($provider);
         } catch (InvalidStateException $e) {
             return $this->invalidStateHandler->handle($e);
         }
 
-        $account = Socialstream::findConnectedAccountForProviderAndId($provider, $providerAccount->getId());
-
-        // Authenticated...
-        if (! is_null($user = Auth::user())) {
-            return $this->alreadyAuthenticated($user, $account, $provider, $providerAccount);
-        }
-
-        // Registration...
-        $previousUrl = session()->get('socialstream.previous_url');
-
-        if (
-            FortifyFeatures::enabled(FortifyFeatures::registration()) && ! $account &&
-            (
-                $previousUrl === route('register') ||
-                (Features::hasCreateAccountOnFirstLoginFeatures() && $previousUrl === route('login'))
-            )
-        ) {
-            $user = Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
-
-            if ($user) {
-                return $this->handleUserAlreadyRegistered($user, $account, $provider, $providerAccount);
-            }
-
-            return $this->register($provider, $providerAccount);
-        }
-
-        if (! Features::hasCreateAccountOnFirstLoginFeatures() && ! $account) {
-            $messageBag = new MessageBag;
-            $messageBag->add(
-                'socialstream',
-                __('An account with this :Provider sign in was not found. Please register or try a different sign in method.', ['provider' => $provider])
-            );
-
-            return redirect()->route('login')->withErrors(
-                $messageBag
-            );
-        }
-
-        if (Features::hasCreateAccountOnFirstLoginFeatures() && ! $account) {
-            if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->exists()) {
-                $messageBag = new MessageBag;
-                $messageBag->add(
-                    'socialstream',
-                    __('An account with that email address already exists. Please login to connect your :Provider account.', ['provider' => $provider])
-                );
-
-                return redirect()->route('login')->withErrors(
-                    $messageBag
-                );
-            }
-
-            $user = $this->createsUser->create($provider, $providerAccount);
-
-            return $this->login($user);
-        }
-
-        $user = $account->user;
-
-        $this->updatesConnectedAccounts->update($user, $account, $provider, $providerAccount);
-
-        $user->forceFill([
-            'current_connected_account_id' => $account->id,
-        ])->save();
-
-        return $this->login($user);
-    }
-
-    /**
-     * Handle connection of accounts for an already authenticated user.
-     */
-    protected function alreadyAuthenticated(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse
-    {
-        if ($account && $account->user_id !== $user->id) {
-            return redirect()->route('profile.show')->dangerBanner(
-                __('This :Provider sign in account is already associated with another user. Please try a different account.', ['provider' => $provider]),
-            );
-        }
-
-        if (! $account) {
-            $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
-
-            return redirect()->route('profile.show')->banner(
-                __('You have successfully connected :Provider to your account.', ['provider' => $provider])
-            );
-        }
-
-        return redirect()->route('profile.show')->dangerBanner(
-            __('This :Provider sign in account is already associated with your user.', ['provider' => $provider]),
-        );
-    }
-
-    /**
-     * Handle when a user is already registered.
-     */
-    protected function handleUserAlreadyRegistered(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
-    {
-        if (Features::hasLoginOnRegistrationFeatures()) {
-
-            // The user exists, but they're not registered with the given provider.
-            if (! $account) {
-                $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
-            }
-
-            return $this->login($user);
-        }
-
-        $messageBag = new MessageBag;
-        $messageBag->add('socialstream', __('An account with that :Provider sign in already exists, please login.', ['provider' => $provider]));
-
-        return redirect()->route('register')->withErrors($messageBag);
-    }
-
-    /**
-     * Handle the registration of a new user.
-     */
-    protected function register(string $provider, ProviderUser $providerAccount): RedirectResponse|LoginResponse
-    {
-        if (! $providerAccount->getEmail()) {
-            $messageBag = new MessageBag;
-            $messageBag->add(
-                'socialstream',
-                __('No email address is associated with this :Provider account. Please try a different account.', ['provider' => $provider])
-            );
-
-            return redirect()->route('register')->withErrors($messageBag);
-        }
-
-        if (Jetstream::newUserModel()->where('email', $providerAccount->getEmail())->exists()) {
-            $messageBag = new MessageBag;
-            $messageBag->add(
-                'socialstream',
-                __('An account with that email address already exists. Please login to connect your :Provider account.', ['provider' => $provider])
-            );
-
-            return redirect()->route('register')->withErrors($messageBag);
-        }
-
-        $user = $this->createsUser->create($provider, $providerAccount);
-
-        return $this->login($user);
-    }
-
-    /**
-     * Authenticate the given user and return a login response.
-     */
-    protected function login(Authenticatable $user): LoginResponse
-    {
-        $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
-
-        return app(LoginResponse::class);
+        return $this->authenticator->authenticate($provider, $providerAccount);
     }
 }

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -2,10 +2,12 @@
 
 namespace JoelButcher\Socialstream;
 
+use JoelButcher\Socialstream\Contracts\AuthenticatesOauthCallback;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
 use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
 use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
+use JoelButcher\Socialstream\Contracts\HandlesOauthCallbackErrors;
 use JoelButcher\Socialstream\Contracts\ResolvesSocialiteUsers;
 use JoelButcher\Socialstream\Contracts\SetsUserPasswords;
 use JoelButcher\Socialstream\Contracts\UpdatesConnectedAccounts;
@@ -256,6 +258,16 @@ class Socialstream
     public static function handlesInvalidStateUsing(callable|string $callback): void
     {
         app()->singleton(HandlesInvalidState::class, $callback);
+    }
+
+    public static function authenticatesOauthCallbackUsing(callable|string $callback): void
+    {
+        app()->singleton(AuthenticatesOauthCallback::class, $callback);
+    }
+
+    public static function handlesOAuthCallbackErrorsUsing(callable|string $callback): void
+    {
+        app()->singleton(HandlesOauthCallbackErrors::class, $callback);
     }
 
     /**

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
+use JoelButcher\Socialstream\Actions\Auth\AuthenticateOauthCallback;
+use JoelButcher\Socialstream\Actions\Auth\HandleOauthCallbackErrors;
 use JoelButcher\Socialstream\Http\Livewire\ConnectedAccountsForm;
 use JoelButcher\Socialstream\Http\Livewire\SetPasswordForm;
 use JoelButcher\Socialstream\Http\Middleware\ShareInertiaData;
@@ -40,6 +42,9 @@ class SocialstreamServiceProvider extends ServiceProvider
         if (config('jetstream.stack') === 'inertia') {
             $this->bootInertia();
         }
+
+        Socialstream::authenticatesOauthCallbackUsing(AuthenticateOauthCallback::class);
+        Socialstream::handlesOAuthCallbackErrorsUsing(HandleOauthCallbackErrors::class);
     }
 
     /**


### PR DESCRIPTION
This PR
- moves the logic used for handling request errors on return back from an OAuth flow to an action
- moves the authentication logic used for creating and authenticating users returning from an OAuth flow into an action
- Allows developers to override both of these via overriding the `authenticatesOauthCallbackUsing` and `handlesOAuthCallbackErrorsUsing` bindings:

```php
Socialstream::authenticatesOauthCallbackUsing(AuthenticateOauthCallback::class);
Socialstream::handlesOAuthCallbackErrorsUsing(HandleOauthCallbackErrors::class);
```