### PR TITLE
[4.x] Use base Symfony response class as return type for `ShareInertiaData`

### DIFF
--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -3,10 +3,7 @@
 namespace JoelButcher\Socialstream\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Inertia\Inertia;
 use JoelButcher\Socialstream\ConnectedAccount;
 use JoelButcher\Socialstream\Socialstream;
@@ -16,7 +13,7 @@ class ShareInertiaData
     /**
      * Handle the incoming request.
      */
-    public function handle(Request $request, Closure $next): Response|RedirectResponse|JsonResponse
+    public function handle(Request $request, Closure $next): \Symfony\Component\HttpFoundation\Response
     {
         Inertia::share(array_filter([
             'socialstream' => function () use ($request) {

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -7,13 +7,14 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use JoelButcher\Socialstream\ConnectedAccount;
 use JoelButcher\Socialstream\Socialstream;
+use Symfony\Component\HttpFoundation\Response
 
 class ShareInertiaData
 {
     /**
      * Handle the incoming request.
      */
-    public function handle(Request $request, Closure $next): \Symfony\Component\HttpFoundation\Response
+    public function handle(Request $request, Closure $next): Response
     {
         Inertia::share(array_filter([
             'socialstream' => function () use ($request) {

--- a/src/Http/Middleware/ShareInertiaData.php
+++ b/src/Http/Middleware/ShareInertiaData.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use JoelButcher\Socialstream\ConnectedAccount;
 use JoelButcher\Socialstream\Socialstream;
-use Symfony\Component\HttpFoundation\Response
+use Symfony\Component\HttpFoundation\Response;
 
 class ShareInertiaData
 {


### PR DESCRIPTION
All of the responses are coming from Symfony HttpFoundation Response object, so optimise it to use it. Also avoids some issues in using Laravel Spark when downloading Stripe receipt.