### PR TITLE
[4.x] use translation for "Connected :at"

### DIFF
--- a/stubs/livewire/resources/views/components/connected-account.blade.php
+++ b/stubs/livewire/resources/views/components/connected-account.blade.php
@@ -37,7 +37,7 @@
 
                 @if (! empty($createdAt))
                     <div class="text-xs text-gray-500">
-                        Connected {{ $createdAt }}
+                        {{ __('Connected :createdAt', ['createdAt' => $createdAt]) }}
                     </div>
                 @else
                     <div class="text-xs text-gray-500">


### PR DESCRIPTION
## Summary <!-- tl;dr one line summary of this PR -->

This pull request is a tiny fix to add the use of default Laravel translation files for the word 'Connected'. 

## Checklist 

- [ x] I've read this template
- [ x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [ x] I've given a good reason as to why this PR exposes new / removes existing user data
