### PR TITLE
[5.x] Publish tests for Filament

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -162,6 +162,12 @@ class InstallCommand extends Command implements PromptsForMissingInput
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output): void
     {
         if ($this->isUsingFilament()) {
+            $input->setOption('pest', select(
+                    label: 'Which testing framework do you prefer?',
+                    options: ['PHPUnit', 'Pest'],
+                    default: $this->isUsingPest() ? 'Pest' : 'PHPUnit'
+                ) === 'Pest');
+
             return;
         }
 
@@ -215,6 +221,7 @@ class InstallCommand extends Command implements PromptsForMissingInput
             $input->setOption('pest', select(
                 label: 'Which testing framework do you prefer?',
                 options: ['PHPUnit', 'Pest'],
+                default: $this->isUsingPest() ? 'pest' : 'phpunit'
             ) === 'Pest');
         }
     }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -163,10 +163,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
     {
         if ($this->isUsingFilament()) {
             $input->setOption('pest', select(
-                    label: 'Which testing framework do you prefer?',
-                    options: ['PHPUnit', 'Pest'],
-                    default: $this->isUsingPest() ? 'Pest' : 'PHPUnit'
-                ) === 'Pest');
+                label: 'Which testing framework do you prefer?',
+                options: ['PHPUnit', 'Pest'],
+                default: $this->isUsingPest() ? 'Pest' : 'PHPUnit'
+            ) === 'Pest');
 
             return;
         }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -109,6 +109,12 @@ class InstallCommand extends Command implements PromptsForMissingInput
         return [
             'starter-kit' => function () use ($defaultPrompt) {
                 $callback = match (true) {
+                    ($this->isFilamentInstalled() && $this->isLaravelBreezeInstalled()) ||
+                    ($this->isFilamentInstalled() && $this->isLaravelJetstreamInstalled()) => function () use ($defaultPrompt) {
+                        warning('It looks like you have multiple starter kits / stacks installed.');
+
+                        return $defaultPrompt;
+                    },
                     $this->isFilamentInstalled() => function () use ($defaultPrompt) {
                         alert('We\'ve detected that Filament is installed.');
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -89,47 +89,61 @@ class InstallCommand extends Command implements PromptsForMissingInput
      */
     protected function promptForMissingArgumentsUsing(): array
     {
+        $defaultPrompt = function () {
+            \Laravel\Prompts\info('Socialstream supports Laravel Breeze, Laravel Jetstream, and Filament.');
+
+            return InstallStarterKit::from(select(
+                label: 'Which development starter kit would you like to use?',
+                options: array_merge(
+                    [
+                        'breeze' => 'Laravel Breeze',
+                        'jetstream' => 'Laravel Jetstream',
+                    ],
+                    // If filament is installed, the user has already told us they don't want to install for that starter kit.
+                    $this->isFilamentInstalled() ? [] : ['filament' => 'Filament Admin Panel'],
+                ),
+                scroll: 10,
+            ));
+        };
+
         return [
-            'starter-kit' => function () {
+            'starter-kit' => function () use ($defaultPrompt) {
                 $callback = match (true) {
-                    $this->isLaravelBreezeInstalled() => function () {
-                        alert('We\'ve detected that Laravel Breeze is installed.');
+                    $this->isFilamentInstalled() => function () use ($defaultPrompt) {
+                        alert('We\'ve detected that Filament is installed.');
 
-                        return InstallStarterKit::Breeze;
-                    },
-                    $this->isLaravelJetstreamInstalled() => function () {
-                        alert('We\'ve detected that Laravel Jetstream is installed.');
-
-                        return InstallStarterKit::Jetstream;
-                    },
-                    default => function () {
-                        if ($this->isFilamentInstalled()) {
-                            alert('We\'ve detected that Filament is installed.');
-
-                            if (confirm(
-                                label: 'Would you like to install Socialstream for Filament?',
-                                default: 'no',
-                                hint: 'If you are also using Laravel Jetstream or Breeze, this will not affect those installations.'
-                            )) {
-                                return InstallStarterKit::Filament;
-                            }
+                        if (confirm(
+                            label: 'Would you like to install Socialstream for Filament?',
+                            hint: 'If you are also using Laravel Jetstream or Breeze, this will not affect those installations.'
+                        )) {
+                            return InstallStarterKit::Filament;
                         }
 
-                        \Laravel\Prompts\info('Socialstream supports Laravel Breeze, Laravel Jetstream, and Filament.');
+                        return $defaultPrompt();
+                    },
+                    $this->isLaravelBreezeInstalled() => function () use ($defaultPrompt) {
+                        alert('We\'ve detected that Laravel Breeze is installed.');
 
-                        return InstallStarterKit::from(select(
-                            label: 'Which development starter kit would you like to use?',
-                            options: array_merge(
-                                [
-                                    'breeze' => 'Laravel Breeze',
-                                    'jetstream' => 'Laravel Jetstream',
-                                ],
-                                // If filament is installed, the user has already told us they don't want to install for that starter kit.
-                                $this->isFilamentInstalled() ? [] : ['filament' => 'Filament Admin Panel'],
-                            ),
-                            scroll: 10,
-                        ));
-                    }
+                        if (confirm(
+                            label: 'Would you like to install Socialstream for Laravel Breeze?',
+                        )) {
+                            return InstallStarterKit::Breeze;
+                        }
+
+                        return $defaultPrompt();
+                    },
+                    $this->isLaravelJetstreamInstalled() => function () use ($defaultPrompt) {
+                        alert('We\'ve detected that Laravel Jetstream is installed.');
+
+                        if (confirm(
+                            label: 'Would you like to install Socialstream for Laravel Jetstream?',
+                        )) {
+                            return InstallStarterKit::Jetstream;
+                        }
+
+                        return $defaultPrompt();
+                    },
+                    default => $defaultPrompt,
                 };
 
                 return $callback();

--- a/src/Installer/Drivers/Filament/FilamentDriver.php
+++ b/src/Installer/Drivers/Filament/FilamentDriver.php
@@ -5,6 +5,7 @@ namespace JoelButcher\Socialstream\Installer\Drivers\Filament;
 use Illuminate\Filesystem\Filesystem;
 use JoelButcher\Socialstream\Installer\Drivers\Driver;
 use JoelButcher\Socialstream\Installer\Enums\InstallOptions;
+use JoelButcher\Socialstream\Installer\Enums\TestRunner;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
@@ -97,6 +98,22 @@ PHP.PHP_EOL, $appConfig));
         return $this;
     }
 
+    /**
+     * Copy the Socialstream test files to the apps "tests" directory for the given test runner.
+     */
+    protected function copyTests(TestRunner $testRunner): static
+    {
+        copy(from: match ($testRunner) {
+            TestRunner::Pest => __DIR__.'/../../../../stubs/filament/pest-tests/SocialstreamRegistrationTest.php',
+            TestRunner::PhpUnit => __DIR__.'/../../../../stubs/filament/tests/SocialstreamRegistrationTest.php',
+        }, to: base_path('tests/Feature/SocialstreamRegistrationTest.php'));
+
+        return $this;
+    }
+
+    /**
+     * Remove dark mode classes from the stack, if requested.
+     */
     protected function optionallyRemoveDarkMode(InstallOptions ...$options): static
     {
         $this->removeDarkClasses((new Finder)

--- a/stubs/filament/pest-tests/SocialstreamRegistrationTest.php
+++ b/stubs/filament/pest-tests/SocialstreamRegistrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Providers\RouteServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use JoelButcher\Socialstream\Providers;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+
+uses(RefreshDatabase::class);
+
+test('users can register using socialite providers', function (string $socialiteProvider) {
+    if (! Providers::enabled($socialiteProvider)) {
+        return $this->markTestSkipped("Registration support with the $socialiteProvider provider is not enabled.");
+    }
+
+    $user = (new User())
+        ->map([
+            'id' => 'abcdefgh',
+            'nickname' => 'Jane',
+            'name' => 'Jane Doe',
+            'email' => 'janedoe@example.com',
+            'avatar' => null,
+            'avatar_original' => null,
+        ])
+        ->setToken('user-token')
+        ->setRefreshToken('refresh-token')
+        ->setExpiresIn(3600);
+
+    $provider = m::mock('Laravel\\Socialite\\Two\\'.$socialiteProvider.'Provider');
+    $provider->shouldReceive('user')->once()->andReturn($user);
+
+    Socialite::shouldReceive('driver')->once()->with($socialiteProvider)->andReturn($provider);
+
+    session()->put('socialstream.previous_url', route('register'));
+
+    $response = $this->get("/oauth/$socialiteProvider/callback");
+
+    $this->assertAuthenticated();
+    $response->assertRedirect(RouteServiceProvider::HOME);
+})->with([
+    [Providers::bitbucket()],
+    [Providers::facebook()],
+    [Providers::github()],
+    [Providers::gitlab()],
+    [Providers::google()],
+    [Providers::linkedin()],
+    [Providers::linkedinOpenId()],
+    [Providers::slack()],
+    [Providers::twitterOAuth1()],
+    [Providers::twitterOAuth2()],
+]);

--- a/stubs/filament/tests/SocialstreamRegistrationTest.php
+++ b/stubs/filament/tests/SocialstreamRegistrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Providers\RouteServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use JoelButcher\Socialstream\Providers;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use Tests\TestCase;
+
+class SocialstreamRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider socialiteProvidersDataProvider
+     */
+    public function test_users_can_register_using_socialite_providers(string $socialiteProvider)
+    {
+        if (! Providers::enabled($socialiteProvider)) {
+            return $this->markTestSkipped("Registration support with the $socialiteProvider provider is not enabled.");
+        }
+
+        $user = (new User())
+            ->map([
+                'id' => 'abcdefgh',
+                'nickname' => 'Jane',
+                'name' => 'Jane Doe',
+                'email' => 'janedoe@example.com',
+                'avatar' => null,
+                'avatar_original' => null,
+            ])
+            ->setToken('user-token')
+            ->setRefreshToken('refresh-token')
+            ->setExpiresIn(3600);
+
+        $provider = m::mock('Laravel\\Socialite\\Two\\'.$socialiteProvider.'Provider');
+        $provider->shouldReceive('user')->once()->andReturn($user);
+
+        Socialite::shouldReceive('driver')->once()->with($socialiteProvider)->andReturn($provider);
+
+        session()->put('socialstream.previous_url', route('register'));
+
+        $response = $this->get("/oauth/$socialiteProvider/callback");
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(RouteServiceProvider::HOME);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function socialiteProvidersDataProvider(): array
+    {
+        return [
+            [Providers::bitbucket()],
+            [Providers::facebook()],
+            [Providers::github()],
+            [Providers::gitlab()],
+            [Providers::google()],
+            [Providers::linkedin()],
+            [Providers::linkedinOpenId()],
+            [Providers::slack()],
+            [Providers::twitterOAuth1()],
+            [Providers::twitterOAuth2()],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:
- Prompts users to select their test runner when installing for Filament Admin Panel
- Publishes PHPUnit or Pest feature tests for Filament Admin Panel
- Prompts the user to select a starter kit if there is a clash of multiple starter kits (e.g. Filament **AND** Laravel Breeze are installed)