### PR TITLE
[5.x] Fix `update-changelog` workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,9 +1,8 @@
 name: update changelog
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
 
 jobs:
   update:


### PR DESCRIPTION
Fixes the `update-changelog` workflow file to run on release