### PR TITLE
[5.x] Remove StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,0 @@
-php:
-  preset: laravel
-
-js: true


### PR DESCRIPTION
Removes the `.styleci.yml` config file from VSC for 5.x as coding standards have moved over to Laravel Pint