### PR TITLE
[4.x] Use Laravel Pint 🍺

### DIFF
--- a/.github/workflows/fix-code-styling.yml
+++ b/.github/workflows/fix-code-styling.yml
@@ -1,0 +1,13 @@
+name: "Fix Code Styling"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  lint:
+    uses: laravel/.github/.github/workflows/coding-standards.yml@main

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,0 @@
-php:
-  preset: laravel
-
-js: true


### PR DESCRIPTION
Updates 4.x to use Laravel Pint instead of StyleCI