### PR TITLE
[5.x] Fix call to undefined method `except` on `$errors`

### DIFF
--- a/stubs/jetstream/livewire/resources/views/components/validation-errors.blade.php
+++ b/stubs/jetstream/livewire/resources/views/components/validation-errors.blade.php
@@ -4,7 +4,7 @@
         <div class="font-medium text-red-600 dark:text-red-400">{{ __('Whoops! Something went wrong.') }}</div>
 
         <ul class="mt-3 list-disc list-inside text-sm text-red-600 dark:text-red-400">
-            @foreach ($errors->except('socialstream')->all() as $error)
+            @foreach ($errors->all() as $error)
                 <li>{{ $error }}</li>
             @endforeach
         </ul>


### PR DESCRIPTION
resolves #303 