### PR TITLE
[5.x] fix: duplicate route names

### DIFF
--- a/routes/socialstream-inertia.php
+++ b/routes/socialstream-inertia.php
@@ -10,8 +10,7 @@ use Laravel\Jetstream\Jetstream;
 
 Route::group(['middleware' => config('socialstream.middleware', ['web'])], function () {
     Route::get('/oauth/{provider}', [OAuthController::class, 'redirect'])->name('oauth.redirect');
-    Route::get('/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
-    Route::post('/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
+    Route::match(['get', 'post'], '/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
 
     Route::delete('/user/connected-account/{id}', [ConnectedAccountController::class, 'destroy'])
         ->middleware(['auth'])

--- a/routes/socialstream.php
+++ b/routes/socialstream.php
@@ -5,6 +5,5 @@ use JoelButcher\Socialstream\Http\Controllers\OAuthController;
 
 Route::group(['middleware' => config('socialstream.middleware', ['web'])], function () {
     Route::get('/oauth/{provider}', [OAuthController::class, 'redirect'])->name('oauth.redirect');
-    Route::get('/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
-    Route::post('/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
+    Route::match(['get', 'post'], '/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
 });

--- a/src/Actions/AuthenticateOAuthCallback.php
+++ b/src/Actions/AuthenticateOAuthCallback.php
@@ -99,10 +99,10 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
     protected function alreadyAuthenticated(Authenticatable $user, ?ConnectedAccount $account, string $provider, ProviderUser $providerAccount): RedirectResponse
     {
         // Get the route
-        $route = match(true) {
+        $route = match (true) {
             Route::has('filament.admin.home') => route('filament.admin.home'),
             Route::has('filament.home') => route('filament.home'),
-            $this->hasComposerPackage('laravel/breeze') => match(true) {
+            $this->hasComposerPackage('laravel/breeze') => match (true) {
                 Route::has('profile.show') => route('profile.show'),
                 Route::has('profile.edit') => route('profile.edit'),
                 Route::has('profile') => route('profile'),

--- a/src/ConnectedAccount.php
+++ b/src/ConnectedAccount.php
@@ -13,8 +13,8 @@ use JoelButcher\Socialstream\Events\ConnectedAccountUpdated;
 class ConnectedAccount extends Model
 {
     use HasFactory;
-    use HasTimestamps;
     use HasOAuth2Tokens;
+    use HasTimestamps;
 
     /**
      * The attributes that are mass assignable.

--- a/src/Policies/ConnectedAccountPolicy.php
+++ b/src/Policies/ConnectedAccountPolicy.php
@@ -2,9 +2,9 @@
 
 namespace JoelButcher\Socialstream\Policies;
 
-use JoelButcher\Socialstream\ConnectedAccount;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use JoelButcher\Socialstream\ConnectedAccount;
 
 class ConnectedAccountPolicy
 {

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -198,7 +198,7 @@ class SocialstreamServiceProvider extends ServiceProvider
         }
 
         Socialstream::setUserPasswordsUsing(SetUserPassword::class);
-        Socialstream::createUsersFromProviderUsing(match(Jetstream::hasTeamFeatures()) {
+        Socialstream::createUsersFromProviderUsing(match (Jetstream::hasTeamFeatures()) {
             true => CreateUserWithTeamsFromProvider::class,
             false => CreateUserFromProvider::class,
         });
@@ -215,7 +215,6 @@ class SocialstreamServiceProvider extends ServiceProvider
                 });
             });
         }
-
 
         if (! $this->app->runningInConsole()) {
             return;

--- a/tests/Feature/RouteCachingTest.php
+++ b/tests/Feature/RouteCachingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace JoelButcher\Socialstream\Tests\Feature;
+
+use App\Providers\RouteServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\User as SocialiteUser;
+use Mockery;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+
+uses(RefreshDatabase::class);
+
+it('caches routes and redirects to provider', function () {
+    $this->defineCacheRoutes(file_get_contents(
+        __DIR__.'/../../routes/socialstream.php'
+    ));
+
+    get('/oauth/github')
+        ->assertRedirect();
+});
+
+it('caches routes and authenticates via GET', function () {
+    $this->defineCacheRoutes(file_get_contents(
+        __DIR__.'/../../routes/socialstream.php'
+    ));
+
+    $user = (new SocialiteUser())
+        ->map([
+            'id' => fake()->numerify('########'),
+            'nickname' => 'joel',
+            'name' => 'Joel',
+            'email' => 'joel@socialstream.dev',
+            'avatar' => null,
+            'avatar_original' => null,
+        ])
+        ->setToken('user-token')
+        ->setRefreshToken('refresh-token')
+        ->setExpiresIn(3600);
+
+    $provider = Mockery::mock(GithubProvider::class);
+    $provider->shouldReceive('user')->once()->andReturn($user);
+
+    Socialite::shouldReceive('driver')->once()->with('github')->andReturn($provider);
+
+    session()->put('socialstream.previous_url', route('register'));
+
+    get('oauth/github/callback')->assertRedirect(RouteServiceProvider::HOME);
+});
+
+it('caches routes and authenticates via POST', function () {
+    $this->defineCacheRoutes(file_get_contents(
+        __DIR__.'/../../routes/socialstream.php'
+    ));
+
+    $user = (new SocialiteUser())
+        ->map([
+            'id' => fake()->numerify('########'),
+            'nickname' => 'joel',
+            'name' => 'Joel',
+            'email' => 'joel@socialstream.dev',
+            'avatar' => null,
+            'avatar_original' => null,
+        ])
+        ->setToken('user-token')
+        ->setRefreshToken('refresh-token')
+        ->setExpiresIn(3600);
+
+    $provider = Mockery::mock(GithubProvider::class);
+    $provider->shouldReceive('user')->once()->andReturn($user);
+
+    Socialite::shouldReceive('driver')->once()->with('github')->andReturn($provider);
+
+    session()->put('socialstream.previous_url', route('register'));
+
+    post('oauth/github/callback')->assertRedirect(RouteServiceProvider::HOME);
+});

--- a/tests/Feature/RouteCachingTest.php
+++ b/tests/Feature/RouteCachingTest.php
@@ -16,7 +16,7 @@ uses(RefreshDatabase::class);
 
 it('caches routes and redirects to provider', function () {
     $this->defineCacheRoutes(file_get_contents(
-        __DIR__.'/../../routes/socialstream.php'
+        __DIR__.'/../../workbench/routes/web.php'
     ));
 
     get('/oauth/github')
@@ -25,7 +25,7 @@ it('caches routes and redirects to provider', function () {
 
 it('caches routes and authenticates via GET', function () {
     $this->defineCacheRoutes(file_get_contents(
-        __DIR__.'/../../routes/socialstream.php'
+        __DIR__.'/../../workbench/routes/web.php'
     ));
 
     $user = (new SocialiteUser())
@@ -53,7 +53,7 @@ it('caches routes and authenticates via GET', function () {
 
 it('caches routes and authenticates via POST', function () {
     $this->defineCacheRoutes(file_get_contents(
-        __DIR__.'/../../routes/socialstream.php'
+        __DIR__.'/../../workbench/routes/web.php'
     ));
 
     $user = (new SocialiteUser())

--- a/tests/Feature/SocialstreamTest.php
+++ b/tests/Feature/SocialstreamTest.php
@@ -5,7 +5,6 @@ namespace JoelButcher\Socialstream\Tests\Feature;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
@@ -18,9 +17,10 @@ use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Mockery;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+
 use function Pest\Laravel\get;
 
-uses(WithFaker::class, RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
 it('redirects users', function (): void {
     $response = get('http://localhost/oauth/github');
@@ -74,7 +74,7 @@ it('generates a redirect using an overriding closure', function (bool $manageRep
 test('users can register', function (): void {
     $user = (new SocialiteUser())
         ->map([
-            'id' => $githubId = $this->faker->numerify('########'),
+            'id' => $githubId = fake()->numerify('########'),
             'nickname' => 'joel',
             'name' => 'Joel',
             'email' => 'joel@socialstream.dev',
@@ -114,7 +114,7 @@ test('existing users can login', function (): void {
 
     $user->connectedAccounts()->create([
         'provider' => 'github',
-        'provider_id' => $githubId = $this->faker->numerify('########'),
+        'provider_id' => $githubId = fake()->numerify('########'),
         'email' => 'joel@socialstream.dev',
         'token' => Str::random(64),
     ]);
@@ -162,7 +162,7 @@ test('authenticated users can link to provider', function (): void {
 
     $user = (new SocialiteUser())
         ->map([
-            'id' => $githubId = $this->faker->numerify('########'),
+            'id' => $githubId = fake()->numerify('########'),
             'nickname' => 'joel',
             'name' => 'Joel',
             'email' => 'joel@socialstream.dev',
@@ -199,7 +199,7 @@ test('new users can register from login page', function (): void {
 
     $user = (new SocialiteUser())
         ->map([
-            'id' => $githubId = $this->faker->numerify('########'),
+            'id' => $githubId = fake()->numerify('########'),
             'nickname' => 'joel',
             'name' => 'Joel',
             'email' => 'joel@socialstream.dev',
@@ -242,7 +242,7 @@ test('users can login on registration', function (): void {
 
     $user = (new SocialiteUser())
         ->map([
-            'id' => $githubId = $this->faker->numerify('########'),
+            'id' => $githubId = fake()->numerify('########'),
             'nickname' => 'joel',
             'name' => 'Joel',
             'email' => 'joel@socialstream.dev',
@@ -278,7 +278,7 @@ it('generates missing emails', function (): void {
 
     $user = (new SocialiteUser())
         ->map([
-            'id' => $githubId = $this->faker->numerify('########'),
+            'id' => $githubId = fake()->numerify('########'),
             'nickname' => 'joel',
             'name' => 'Joel',
             'avatar' => null,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,4 +40,9 @@ abstract class TestCase extends BaseTestCase
             'redirect' => 'https://example.test/oauth/github/callback',
         ]);
     }
+
+    protected function migrate(): void
+    {
+        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace JoelButcher\Socialstream\Tests;
 
-use Illuminate\Support\Facades\Config;
 use JoelButcher\Socialstream\SocialstreamServiceProvider;
 use Laravel\Socialite\SocialiteServiceProvider;
 use Mockery;
@@ -10,19 +9,10 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Config::set('services.github', [
-            'client_id' => 'github-client-id',
-            'client_secret' => 'github-client-secret',
-            'redirect' => 'https://example.test/oauth/github/callback',
-        ]);
-    }
-
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         Mockery::close();
     }
 
@@ -43,10 +33,11 @@ abstract class TestCase extends BaseTestCase
             'database' => ':memory:',
             'prefix' => '',
         ]);
-    }
 
-    protected function migrate(): void
-    {
-        $this->artisan('migrate', ['--database' => 'testbench'])->run();
+        $app['config']->set('services.github', [
+            'client_id' => 'github-client-id',
+            'client_secret' => 'github-client-secret',
+            'redirect' => 'https://example.test/oauth/github/callback',
+        ]);
     }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use JoelButcher\Socialstream\Http\Controllers\OAuthController;
+
+Route::group(['middleware' => config('socialstream.middleware', ['web'])], function () {
+    Route::get('/oauth/{provider}', [OAuthController::class, 'redirect'])->name('oauth.redirect');
+    Route::match(['get', 'post'], '/oauth/{provider}/callback', [OAuthController::class, 'callback'])->name('oauth.callback');
+});
+
+Route::post('/login', function () {
+    return 'login';
+})->name('login');
+
+Route::post('/register', function () {
+    return 'register';
+})->name('register');


### PR DESCRIPTION
Uses `Route::match(…)` to resolve the OAuth callback for both GET and POST HTTP verbs in order to cache the route for both methods with the same name.

Addresses issues identified in #288 