### PR TITLE
[5.x] Fix Livewire component registration

### DIFF
--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -43,8 +43,10 @@ class SocialstreamServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/socialstream.php', 'socialstream');
 
         if(config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
-            Livewire::component('profile.set-password-form', SetPasswordForm::class);
-            Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
+            $this->app->afterResolving(Livewire::class, function () {
+                Livewire::component('profile.set-password-form', SetPasswordForm::class);
+                Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
+            });
         }
     }
 

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -43,12 +43,12 @@ class SocialstreamServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/socialstream.php', 'socialstream');
 
-        $this->app->afterResolving(LivewireManager::class, function () {
-            if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+        if(config('jetstream.stack') === 'livewire' && class_exists(LivewireManager::class)) {
+            $this->app->afterResolving(LivewireManager::class, function () {
                 Livewire::component('profile.set-password-form', SetPasswordForm::class);
                 Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
-            }
-        });
+            });
+        }
     }
 
     /**

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -41,13 +41,6 @@ class SocialstreamServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/socialstream.php', 'socialstream');
-
-        if(config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
-            $this->app->afterResolving(Livewire::class, function () {
-                Livewire::component('profile.set-password-form', SetPasswordForm::class);
-                Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
-            });
-        }
     }
 
     /**
@@ -62,6 +55,11 @@ class SocialstreamServiceProvider extends ServiceProvider
         $this->bootLaravelJetstream();
         $this->bootFilament();
         $this->bootInertia();
+        
+        if(config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+            Livewire::component('profile.set-password-form', SetPasswordForm::class);
+            Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
+        }
     }
 
     /**

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -30,7 +30,6 @@ use JoelButcher\Socialstream\Resolvers\OAuth\SlackOAuth2RefreshResolver;
 use JoelButcher\Socialstream\Resolvers\OAuth\TwitterOAuth2RefreshResolver;
 use Laravel\Jetstream\Jetstream;
 use Livewire\Livewire;
-use Livewire\LivewireManager;
 
 class SocialstreamServiceProvider extends ServiceProvider
 {
@@ -43,11 +42,9 @@ class SocialstreamServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/socialstream.php', 'socialstream');
 
-        if(config('jetstream.stack') === 'livewire' && class_exists(LivewireManager::class)) {
-            $this->app->afterResolving(LivewireManager::class, function () {
-                Livewire::component('profile.set-password-form', SetPasswordForm::class);
-                Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
-            });
+        if(config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
+            Livewire::component('profile.set-password-form', SetPasswordForm::class);
+            Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
         }
     }
 

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\Compilers\BladeCompiler;
 use JoelButcher\Socialstream\Actions\AuthenticateOAuthCallback;
 use JoelButcher\Socialstream\Actions\CreateConnectedAccount;
 use JoelButcher\Socialstream\Actions\CreateUserFromProvider;
@@ -31,6 +30,7 @@ use JoelButcher\Socialstream\Resolvers\OAuth\SlackOAuth2RefreshResolver;
 use JoelButcher\Socialstream\Resolvers\OAuth\TwitterOAuth2RefreshResolver;
 use Laravel\Jetstream\Jetstream;
 use Livewire\Livewire;
+use Livewire\LivewireManager;
 
 class SocialstreamServiceProvider extends ServiceProvider
 {
@@ -43,7 +43,7 @@ class SocialstreamServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/socialstream.php', 'socialstream');
 
-        $this->app->afterResolving(BladeCompiler::class, function () {
+        $this->app->afterResolving(LivewireManager::class, function () {
             if (config('jetstream.stack') === 'livewire' && class_exists(Livewire::class)) {
                 Livewire::component('profile.set-password-form', SetPasswordForm::class);
                 Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);


### PR DESCRIPTION
## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
Fix **Unable to find component** with [livewire v3.2.0](https://github.com/livewire/livewire/releases/v3.2.0)

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->

[//]: # (copilot:walkthrough)
I don't know what exact [changes made between 3.1 to 3.2](https://github.com/livewire/livewire/compare/v3.1.0...v3.2.0) is causing this problem but my pull request fix the error anyway

Screenshot for context
<img width="600" alt="image" src="https://github.com/joelbutcher/socialstream/assets/1408020/3e89a5ab-281b-4be0-ad32-90420e6741e8">

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [X] I've read this template
- [X] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [X] I've given a good reason as to why this PR exposes new / removes existing user data
