### PR TITLE
fix: remove typehint to be compatible with Socialite AbstractProvider

### DIFF
--- a/src/Concerns/RefreshesOAuth2Tokens.php
+++ b/src/Concerns/RefreshesOAuth2Tokens.php
@@ -19,8 +19,12 @@ trait RefreshesOAuth2Tokens
      *
      * @throws GuzzleException
      */
-    public function refreshToken(ConnectedAccount $connectedAccount): RefreshedCredentials
+    public function refreshToken($connectedAccount): RefreshedCredentials
     {
+        if(!$connectedAccount instanceof ConnectedAccount) {
+            throw new \RuntimeException('Given parameter must be of type ConnectedAccount.');
+        }
+
         if (is_null($connectedAccount->refresh_token)) {
             throw new \RuntimeException('A valid refresh token is required.');
         }


### PR DESCRIPTION
## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
This pull request...

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->
RefreshesOAuth2Tokens is no longer compatible with Laravel Socialite's [AbstractProvider](https://github.com/laravel/socialite/blob/5.x/src/Two/AbstractProvider.php). [They added the method refreshToken 2 Months ago](https://github.com/laravel/socialite/commit/dc14fca52f0d38c118c6746a967d9eaa4a5cbf2f) which now conflicts with the trait.


[//]: # (copilot:walkthrough)
<!-- List the changes and why they were made -->

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [x] I've given a good reason as to why this PR exposes new / removes existing user data
