### PR TITLE
[5.x] Fix user being able to link account without loginOnRegistration()

### DIFF
--- a/src/Actions/AuthenticateOAuthCallback.php
+++ b/src/Actions/AuthenticateOAuthCallback.php
@@ -53,39 +53,21 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
      */
     public function authenticate(string $provider, ProviderUser $providerAccount): SocialstreamResponse|RedirectResponse
     {
-        if (auth()->check()) {
-            return $this->linkProvider($provider, $providerAccount);
-        }
-
-        if (
-            Route::has('register') &&
-            session()->get('socialstream.previous_url') === route('register')
-        ) {
-            return $this->register($provider, $providerAccount);
-        }
-
-        if (
-            !Features::hasGlobalLoginFeatures() &&
-            Route::has('login') &&
-            session()->get('socialstream.previous_url') !== route('login')
-        ) {
-            event(new OAuthLoginFailed($provider, $providerAccount));
-
-            $this->flashError(
-                'This action is unauthorized.'
-            );
-
-            return app(OAuthLoginFailedResponse::class);
+        // User authenticated... Trying to link a new provider
+        if ($user = auth()->user()) {
+            return $this->linkProvider($user, $provider, $providerAccount);
         }
 
         $user = Socialstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
 
+        // User is not registered yet...
         if (! $user) {
-            if (Features::hasCreateAccountOnFirstLoginFeatures()) {
+            if (
+                (Route::has('register') && session()->get('socialstream.previous_url') === route('register'))
+                || Features::hasCreateAccountOnFirstLoginFeatures() && (session()->get('socialstream.previous_url') === route('login') || Features::hasGlobalLoginFeatures())
+            ) {
                 return $this->register($provider, $providerAccount);
             }
-
-            event(new OAuthLoginFailed($provider, $providerAccount));
 
             $this->flashError(
                 __('We could not find your account. Please register to create an account.'),
@@ -94,8 +76,28 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
             return app(OAuthLoginFailedResponse::class);
         }
 
+        $account = $this->findAccount($provider, $providerAccount);
+
+        // User provider account is not linked...
+        if (! $account) {
+            if (Features::hasLoginOnRegistrationFeatures()) {
+                $account = $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
+
+                return $this->login($user, $account, $provider, $providerAccount);
+            }
+
+            event(new OAuthRegistrationFailed($provider, $account, $providerAccount));
+
+            $this->flashError(
+                __('An account already exists for that email address. Please login to connect your :provider account.', ['provider' => Providers::name($provider)]),
+            );
+
+            return app(OAuthRegisterFailedResponse::class);
+        }
+
         return $this->login(
             $user,
+            $account,
             $provider,
             $providerAccount
         );
@@ -106,66 +108,21 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
      */
     protected function register(string $provider, ProviderUser $providerAccount): SocialstreamResponse
     {
-        $account = $this->findAccount($provider, $providerAccount);
-        $user = Socialstream::newUserModel()->where('email', $providerAccount->getEmail())->first();
+        $user = $this->createsUser->create($provider, $providerAccount);
 
-        if (! $user && !$account) {
-            $user = $this->createsUser->create($provider, $providerAccount);
+        $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
 
-            $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
+        event(new NewOAuthRegistration($user, $provider, $providerAccount));
 
-            event(new NewOAuthRegistration($user, $provider, $providerAccount));
-
-            return app(OAuthRegisterResponse::class);
-        }
-
-        if ($user && !Features::hasLoginOnRegistrationFeatures()) {
-            event(new OAuthRegistrationFailed($provider, $account, $providerAccount));
-
-            $this->flashError(
-                __('An account already exists for that email address. Please login to connect your :provider account.', ['provider' => Providers::name($provider)]),
-            );
-
-            return app(OAuthRegisterFailedResponse::class);
-        }
-
-        $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
-
-        return $this->login(
-            $user,
-            $provider,
-            $providerAccount,
-        );
+        return app(OAuthRegisterResponse::class);
     }
 
     /**
      * Authenticate the given user and return a login response.
      */
-    protected function login(Authenticatable $user, string $provider, ProviderUser $providerAccount): SocialstreamResponse
+    protected function login(Authenticatable $user, mixed $account, string $provider, ProviderUser $providerAccount): SocialstreamResponse
     {
-        $account = $this->findAccount($provider, $providerAccount);
-
-        if ($account) {
-            $this->updatesConnectedAccounts->update($user, $account, $provider, $providerAccount);
-
-            $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
-
-            event(new OAuthLogin($user, $provider, $account, $providerAccount));
-
-            return app(OAuthLoginResponse::class);
-        }
-
-        if (! Features::hasCreateAccountOnFirstLoginFeatures()) {
-            event(new OAuthLoginFailed($provider, $providerAccount));
-
-            $this->flashError(
-                __('We could not find your account. Please register to create an account.'),
-            );
-
-            return app(OAuthLoginFailedResponse::class);
-        }
-
-        $account = $this->createsConnectedAccounts->create($user, $provider, $providerAccount);
+        $this->updatesConnectedAccounts->update($user, $account, $provider, $providerAccount);
 
         $this->guard->login($user, Socialstream::hasRememberSessionFeatures());
 
@@ -177,9 +134,8 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
     /**
      * Attempt to link the provider to the authenticated user.
      */
-    private function linkProvider(string $provider, ProviderUser $providerAccount): SocialstreamResponse
+    private function linkProvider(Authenticatable $user, string $provider, ProviderUser $providerAccount): SocialstreamResponse
     {
-        $user = auth()->user();
         $account = $this->findAccount($provider, $providerAccount);
 
         // Account exists

--- a/src/Actions/AuthenticateOAuthCallback.php
+++ b/src/Actions/AuthenticateOAuthCallback.php
@@ -69,6 +69,8 @@ class AuthenticateOAuthCallback implements AuthenticatesOAuthCallback
                 return $this->register($provider, $providerAccount);
             }
 
+            event(new OAuthLoginFailed($provider, $providerAccount));
+
             $this->flashError(
                 __('We could not find your account. Please register to create an account.'),
             );

--- a/tests/Feature/CreateAccountOnFirstLoginTest.php
+++ b/tests/Feature/CreateAccountOnFirstLoginTest.php
@@ -153,7 +153,7 @@ test('new users cannot register from random page without feature enabled', funct
 
     get('http://localhost/oauth/github/callback')
         ->assertRedirect(route('login'))
-        ->assertSessionHasErrors(['socialstream' => 'This action is unauthorized.']);
+        ->assertSessionHasErrors(['socialstream' => 'We could not find your account. Please register to create an account.']);
 
     $this->assertGuest();
 });

--- a/tests/Feature/LoginOnRegistrationTest.php
+++ b/tests/Feature/LoginOnRegistrationTest.php
@@ -61,3 +61,81 @@ test('users can login on registration', function (): void {
         'email' => 'joel@socialstream.dev',
     ]);
 });
+
+test('users cannot login on registration without feature enabled', function (): void {
+    User::create([
+        'name' => 'Joel Butcher',
+        'email' => 'joel@socialstream.dev',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->assertDatabaseHas('users', ['email' => 'joel@socialstream.dev']);
+    $this->assertDatabaseEmpty('connected_accounts');
+
+    $user = (new SocialiteUser())
+        ->map([
+            'id' => $githubId = fake()->numerify('########'),
+            'nickname' => 'joel',
+            'name' => 'Joel',
+            'email' => 'joel@socialstream.dev',
+            'avatar' => null,
+            'avatar_original' => null,
+        ])
+        ->setToken('user-token')
+        ->setRefreshToken('refresh-token')
+        ->setExpiresIn(3600);
+
+    $provider = Mockery::mock(GithubProvider::class);
+    $provider->shouldReceive('user')->once()->andReturn($user);
+
+    Socialite::shouldReceive('driver')->once()->with('github')->andReturn($provider);
+
+    session()->put('socialstream.previous_url', route('register'));
+
+    $response = get('http://localhost/oauth/github/callback');
+
+    $this->assertGuest();
+    $response->assertRedirect(route('register'));
+    $response->assertSessionHasErrors();
+});
+
+test('users cannot login on registration from random route without feature enabled (but globalLogin + createAccountOnFirstLogin)', function (): void {
+    Config::set('socialstream.features', [
+        Features::globalLogin(),
+        Features::createAccountOnFirstLogin(),
+    ]);
+
+    User::create([
+        'name' => 'Joel Butcher',
+        'email' => 'joel@socialstream.dev',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->assertDatabaseHas('users', ['email' => 'joel@socialstream.dev']);
+    $this->assertDatabaseEmpty('connected_accounts');
+
+    $user = (new SocialiteUser())
+        ->map([
+            'id' => $githubId = fake()->numerify('########'),
+            'nickname' => 'joel',
+            'name' => 'Joel',
+            'email' => 'joel@socialstream.dev',
+            'avatar' => null,
+            'avatar_original' => null,
+        ])
+        ->setToken('user-token')
+        ->setRefreshToken('refresh-token')
+        ->setExpiresIn(3600);
+
+    $provider = Mockery::mock(GithubProvider::class);
+    $provider->shouldReceive('user')->once()->andReturn($user);
+
+    Socialite::shouldReceive('driver')->once()->with('github')->andReturn($provider);
+
+    session()->put('socialstream.previous_url', '/random');
+
+    $response = get('http://localhost/oauth/github/callback');
+
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+});


### PR DESCRIPTION
The refactoring from https://github.com/joelbutcher/socialstream/pull/325 flushed the OAuth logic again, making it very hard to understand how the authentication flow works. On top of that, it introduced a vulnerability/bug where the user can link a provider account to an existing account without the `loginOnRegistration()` feature enabled.

To reproduce, the system must have `Features::globalLogin()` and `Features::createAccountOnFirstLogin()` enabled, and the user needs to authenticate using a non-linked provider from a random route.


### How can it be better organized? (From my point of view)
The first point I observed is that Oauth is using multiple points to create an account (or provider account) again. You can see that `$this->createsConnectedAccounts->create()` is used three times and `$this->register()` two times, opening gaps for problems like the one that was identified.

You may also see that `$this->login()` has the responsibility to "create the connected account", while it is being used on `$this->register` which already has this responsibility... It is very difficult to understand when creating the account will be used at each point.

We should keep the flow simple and reduce the times the code can create or link an account. This PR also aims to simplify this flow again.