### PR TITLE
Fix password error not working when desconnecting account for Jetstream -> Inertia.js

### DIFF
--- a/src/Http/Controllers/Inertia/ConnectedAccountController.php
+++ b/src/Http/Controllers/Inertia/ConnectedAccountController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Laravel\Fortify\Actions\ConfirmPassword;
 use JoelButcher\Socialstream\Socialstream;
 
 class ConnectedAccountController extends Controller
@@ -14,15 +16,15 @@ class ConnectedAccountController extends Controller
     /**
      * Delete a connected account.
      */
-    public function destroy(Request $request, string|int $id): RedirectResponse
+    public function destroy(Request $request, StatefulGuard $guard, string|int $id): RedirectResponse
     {
-        $request->validateWithBag('connectedAccountRemoval', [
-            'password' => ['required', 'current_password'],
-        ]);
+        $confirmed = app(ConfirmPassword::class)(
+            $guard, $request->user(), $request->password
+        );
 
-        if (! Hash::check($request->password, $request->user()->getAuthPassword())) {
+        if (! $confirmed) {
             throw ValidationException::withMessages([
-                'password' => [__('This password does not match our records.')],
+                'password' => __('The password is incorrect.'),
             ]);
         }
 


### PR DESCRIPTION
## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
This pull request fixes the password error not working for the Inertia.js version (even for fresh installs) when disconnecting social accounts. It also changes the password confirmation logic to the same as Jetstream:

https://github.com/laravel/jetstream/blob/4.x/src/Http/Controllers/Inertia/CurrentUserController.php

Since this endpoint is only used by Jetstream + Inertia.js, this change does not affect the other Socialstream implementations.

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [ ] I've read this template
- [ ] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [ ] I've given a good reason as to why this PR exposes new / removes existing user data
