### PR TITLE
[5.x] Improve Google callback error compatibility

### DIFF
--- a/src/Actions/HandleOAuthCallbackErrors.php
+++ b/src/Actions/HandleOAuthCallbackErrors.php
@@ -22,7 +22,7 @@ class HandleOAuthCallbackErrors implements HandlesOAuthCallbackErrors
             return null;
         }
 
-        $error = $request->get('error_description');
+        $error = $request->get('error_description', $request->get('error'));
 
         // Because users can have multiple stacks installed for which they may wish to use
         // Socialstream for, we will need to determine the redirect path based on a few


### PR DESCRIPTION
To handle exception when callback url from Google does not contain error_description

## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
This pull request is to fix the issue where Google SignIn callback does not contain `error_description` when click cancel button.

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->
Google callback url only contain `error` and `state`, missing `error_description`

Google Callback: `/oauth/google/callback?error=access_denied&state=----`
