### PR TITLE
[5.x] Fix removed cancel modal toggle action

### DIFF
--- a/stubs/jetstream/livewire/resources/views/profile/connected-accounts-form.blade.php
+++ b/stubs/jetstream/livewire/resources/views/profile/connected-accounts-form.blade.php
@@ -68,7 +68,7 @@
             </x-slot>
 
             <x-slot name="footer">
-                <x-secondary-button wire:click="$toggle('confirmingRemove')" wire:loading.attr="disabled">
+                <x-secondary-button wire:click="$toggle('confirmingAccountRemoval')" wire:loading.attr="disabled">
                     {{ __('Cancel') }}
                 </x-secondary-button>
 


### PR DESCRIPTION
### Problem description

At line 71, of the `connected-accounts-form.blade.php`

The value : 

 `"$toggle('confirmingRemove')"` 

does not seems to exist anymore, it should be remove by : 

 `"$toggle('confirmingAccountRemoval')"`

```
   <x-slot name="footer">
                <x-secondary-button wire:click="$toggle('confirmingRemove')" wire:loading.attr="disabled">
                    {{ __('Cancel') }}
                </x-secondary-button>

                <x-danger-button class="ml-2" wire:click="removeConnectedAccount" wire:loading.attr="disabled">
                    {{ __('Remove Account') }}
                </x-danger-button>
            </x-slot>
```

### Expected behavior

Should be : 

```
 <x-slot name="footer">
                <x-secondary-button wire:click="$toggle('confirmingAccountRemoval')" wire:loading.attr="disabled">
                    {{ __('Cancel') }}
                </x-secondary-button>

                <x-danger-button class="ml-2" wire:click="removeConnectedAccount" wire:loading.attr="disabled">
                    {{ __('Remove Account') }}
                </x-danger-button>
            </x-slot>
```
