### PR TITLE
[5.x]: Allow HandlesInvalidState to return an instance of RedirectResponse

### DIFF
--- a/src/Contracts/HandlesInvalidState.php
+++ b/src/Contracts/HandlesInvalidState.php
@@ -2,6 +2,7 @@
 
 namespace JoelButcher\Socialstream\Contracts;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Laravel\Socialite\Two\InvalidStateException;
 
@@ -10,5 +11,5 @@ interface HandlesInvalidState
     /**
      * Handle an invalid state exception from a Socialite provider.
      */
-    public function handle(InvalidStateException $exception): Response;
+    public function handle(InvalidStateException $exception): Response | RedirectResponse;
 }


### PR DESCRIPTION
In certain cases, it would be great if the HandlesInvalidState class could also return a RedirectResponse object.

Much simpler when you want to redirect in case of error Invalid State exception

@joelbutcher 