### PR TITLE
[6.x] Remove import to stop compiler warnings in ConnectedAccount.vue

### DIFF
--- a/stubs/jetstream/inertia/resources/js/Components/ConnectedAccount.vue
+++ b/stubs/jetstream/inertia/resources/js/Components/ConnectedAccount.vue
@@ -1,5 +1,4 @@
 <script setup>
-import {defineProps} from 'vue';
 import ProviderIcon from '@/Components/SocialstreamIcons/ProviderIcon.vue';
 
 const props = defineProps({


### PR DESCRIPTION
The `ConnectedAccount.vue` component is currently importing the defineProps. However, the importing is not needed, and the component is giving compiling warnings on fresh installs.

![image](https://github.com/joelbutcher/socialstream/assets/35383529/39586be7-1eba-4f6e-a61b-2589ed65eed2)


[//]: # (copilot:walkthrough)
<!-- List the changes and why they were made -->

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [x] I've given a good reason as to why this PR exposes new / removes existing user data
