### PR TITLE
[6.x] Use framework Password validation rule

### DIFF
--- a/stubs/app/Actions/Socialstream/SetUserPassword.php
+++ b/stubs/app/Actions/Socialstream/SetUserPassword.php
@@ -4,8 +4,8 @@ namespace App\Actions\Socialstream;
 
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
 use JoelButcher\Socialstream\Contracts\SetsUserPasswords;
-use Laravel\Fortify\Rules\Password;
 
 class SetUserPassword implements SetsUserPasswords
 {
@@ -15,7 +15,7 @@ class SetUserPassword implements SetsUserPasswords
     public function set(mixed $user, array $input): void
     {
         Validator::make($input, [
-            'password' => ['required', 'string', new Password, 'confirmed'],
+            'password' => ['required', 'string', Password::default(), 'confirmed'],
         ])->validateWithBag('setPassword');
 
         $user->forceFill([


### PR DESCRIPTION
Fortify deprecated its password validation class (see https://github.com/laravel/fortify/pull/511). Now, they are using the new `Illuminate\Validation\Rules\Password` class. This PR updates the socialstream stub to use the new validation class too.

[//]: # (copilot:walkthrough)
<!-- List the changes and why they were made -->

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [x] I've given a good reason as to why this PR exposes new / removes existing user data
