### PR TITLE
[6.x] Remove webmozart/assert package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "php": "^8.2",
         "illuminate/contracts": "^11.0",
         "laravel/prompts": "^0.1.10",
-        "laravel/socialite": "^5.12",
-        "webmozart/assert": "^1.11"
+        "laravel/socialite": "^5.12"
     },
     "require-dev": {
         "laravel/breeze": "^2.0",

--- a/src/Data/ProviderData.php
+++ b/src/Data/ProviderData.php
@@ -4,7 +4,6 @@ namespace JoelButcher\Socialstream\Data;
 
 use JoelButcher\Socialstream\Enums\ProviderEnum;
 use JoelButcher\Socialstream\Providers;
-use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -16,15 +15,23 @@ final class ProviderData
         public readonly string $name,
         public readonly ?string $buttonLabel = null,
     ) {
-        Assert::stringNotEmpty($id);
-        Assert::stringNotEmpty($name);
+        if ($id === '') {
+            throw new \InvalidArgumentException('Expected a different value than \'\'');
+        }
+        if ($name === '') {
+            throw new \InvalidArgumentException('Expected a different value than \'\'');
+        }
     }
 
     public static function from(ProviderEnum|string|array $provider): self
     {
         if (is_array($provider)) {
-            Assert::keyExists($provider, 'id');
-            Assert::keyExists($provider, 'name');
+            if (! array_key_exists('id', $provider)) {
+                throw new \InvalidArgumentException('Expected the key \'id\' to exist');
+            }
+            if (! array_key_exists('name', $provider)) {
+                throw new \InvalidArgumentException('Expected the key \'name\' to exist');
+            }
         }
 
         return match (true) {


### PR DESCRIPTION
## Summary

This pull request removes the `webmozart/assert` package. The package is used in only one file to throw `InvalidArgumentException` in some scenarios.  Although these exceptions are never caught, the PR manually adds the exceptions with the exact same messages from the package. 

The motivation for this PR is because the package is giving some strange conflict errors when trying to install `vimeo/psalm` with `socialstream` and `webmozart/asset` with an already composer.lock generated.

Manually adding `vimeo/psalm` to the project and deleting the composer.lock fixes the conflict. However, since this package's last commit was **2 years ago** and is only being used in one single file, I personally don't see a reason to keep it.

## Checklist

- [ ] I've read this template
- [ ] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [ ] I've given a good reason as to why this PR exposes new / removes existing user data
