### PR TITLE
[6.x] Fix syntax error in breeze livewire-functional set-password-form

### DIFF
--- a/stubs/breeze/livewire-functional/resources/views/livewire/profile/set-password-form.blade.php
+++ b/stubs/breeze/livewire-functional/resources/views/livewire/profile/set-password-form.blade.php
@@ -22,7 +22,7 @@ $setPassword = function () {
         throw $e;
     }
 
-    Auth::::user()->update([
+    Auth::user()->update([
         'password' => Hash::make($validated['password']),
     ]);
 


### PR DESCRIPTION
Syntax error: unexpected token Fixx
