### PR TITLE
[6.x] – Override default `EloquentUserProvider` to check $user->authPassword before checking hashes match

### DIFF
--- a/src/Auth/SocialstreamUserProvider.php
+++ b/src/Auth/SocialstreamUserProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoelButcher\Socialstream\Auth;
+
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+
+class SocialstreamUserProvider extends EloquentUserProvider
+{
+    public function validateCredentials(UserContract $user, #[\SensitiveParameter] array $credentials): bool
+    {
+        if (is_null($user->getAuthPassword())) {
+            return false;
+        }
+
+        return parent::validateCredentials($user, $credentials);
+    }
+}

--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -18,6 +18,7 @@ use JoelButcher\Socialstream\Actions\HandleOAuthCallbackErrors;
 use JoelButcher\Socialstream\Actions\ResolveSocialiteUser;
 use JoelButcher\Socialstream\Actions\SetUserPassword;
 use JoelButcher\Socialstream\Actions\UpdateConnectedAccount;
+use JoelButcher\Socialstream\Auth\SocialstreamUserProvider;
 use JoelButcher\Socialstream\Concerns\InteractsWithComposer;
 use JoelButcher\Socialstream\Http\Livewire\ConnectedAccountsForm;
 use JoelButcher\Socialstream\Http\Livewire\SetPasswordForm;
@@ -76,6 +77,7 @@ class SocialstreamServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->configureAuth();
         $this->configureDefaults();
         $this->configureRoutes();
         $this->configureCommands();
@@ -89,6 +91,14 @@ class SocialstreamServiceProvider extends ServiceProvider
             Livewire::component('profile.set-password-form', SetPasswordForm::class);
             Livewire::component('profile.connected-accounts-form', ConnectedAccountsForm::class);
         }
+    }
+
+    private function configureAuth(): void
+    {
+        Auth::provider('eloquent', fn ($app, array $config) => new SocialstreamUserProvider(
+            hasher: $app['hash'],
+            model: $config['model']
+        ));
     }
 
     /**


### PR DESCRIPTION
Resolves #366 

The problem is that when ever anyone has "registered" with a provider, the `users.password` field is set to `NULL` in the database. Therefore attempting to authenticate a user with their email and password throws an error exception, presenting itself as a 500 server error.

The default eloquent user provider (rightly) assumes that the `user.password` column is always filled with a password hash (as is the default behaviour of every Laravel app). This results in the underlying hasher checking a hashed password from the form against `NULL`, which throws the error.

The fix here is to override the `eloquent` user provider with our own user provider. This provider only `extends` the base one and only overrides the methods that matter (in this case only the `validateCredentials` method).