### PR TITLE
[6.x] Fix config not publishing for Laravel Breeze

### DIFF
--- a/src/SocialstreamServiceProvider.php
+++ b/src/SocialstreamServiceProvider.php
@@ -188,7 +188,7 @@ class SocialstreamServiceProvider extends ServiceProvider
         }
 
         $this->publishes([
-            __DIR__.'/../config/socialstream.php.php' => config_path('socialstream.php'),
+            __DIR__.'/../config/socialstream.php' => config_path('socialstream.php'),
         ], 'socialstream-config');
 
         $this->publishes([


### PR DESCRIPTION
Removed an additional .php preventing config files from being published.

## Summary <!-- tl;dr one line summary of this PR -->

[//]: # (copilot:summary)
This pull request fixes an issue preventing the **socialstream.php** configuration file from being published

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->
There was a typo mistake made in `src/SocialstreamServiceProvider.php` that prevented the `config/socialstream.php` file from being published on any installation of Laravel Breeze

[//]: # (copilot:walkthrough)
<!-- List the changes and why they were made -->
- changed line **191** on `src/SocialstreamServiceProvider.php` that fixes a typo in the Socialstream code base.

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [ ] I've given a good reason as to why this PR exposes new / removes existing user data
