### PR TITLE
[6.x] Fix PHP 8.4 deprecation warnings for implicit nullable types

### DIFF
--- a/src/Installer/InstallManager.php
+++ b/src/Installer/InstallManager.php
@@ -14,7 +14,7 @@ use JoelButcher\Socialstream\Installer\Drivers\Jetstream\InertiaDriver;
 use JoelButcher\Socialstream\Installer\Drivers\Jetstream\LivewireDriver as JetstreamLivewireDriver;
 
 /**
- * @method Driver driver($driver = null)
+ * @method Driver driver(?string $driver = null)
  */
 class InstallManager extends Manager
 {

--- a/src/Providers.php
+++ b/src/Providers.php
@@ -152,7 +152,7 @@ class Providers
     /**
      * Enable the Bitbucket provider.
      */
-    public static function bitbucket(string $label = null): string
+    public static function bitbucket(?string $label = null): string
     {
         return tap(ProviderEnum::Bitbucket->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -160,7 +160,7 @@ class Providers
     /**
      * Enable the Facebook provider.
      */
-    public static function facebook(string $label = null): string
+    public static function facebook(?string $label = null): string
     {
         return tap(ProviderEnum::Facebook->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -168,7 +168,7 @@ class Providers
     /**
      * Enable the GitHub provider.
      */
-    public static function github(string $label = null): string
+    public static function github(?string $label = null): string
     {
         return tap(ProviderEnum::Github->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -176,7 +176,7 @@ class Providers
     /**
      * Enable the GitLab provider.
      */
-    public static function gitlab(string $label = null): string
+    public static function gitlab(?string $label = null): string
     {
         return tap(ProviderEnum::Gitlab->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -184,7 +184,7 @@ class Providers
     /**
      * Enable the Google provider.
      */
-    public static function google(string $label = null): string
+    public static function google(?string $label = null): string
     {
         return tap(ProviderEnum::Google->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -192,7 +192,7 @@ class Providers
     /**
      * Enable the LinkedIn provider.
      */
-    public static function linkedin(string $label = null): string
+    public static function linkedin(?string $label = null): string
     {
         return tap(ProviderEnum::LinkedIn->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -200,7 +200,7 @@ class Providers
     /**
      * Enable the LinkedIn OpenID provider.
      */
-    public static function linkedinOpenId(string $label = null): string
+    public static function linkedinOpenId(?string $label = null): string
     {
         return tap(ProviderEnum::LinkedInOpenId->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -208,7 +208,7 @@ class Providers
     /**
      * Enable the Slack provider.
      */
-    public static function slack(string $label = null): string
+    public static function slack(?string $label = null): string
     {
         return tap(ProviderEnum::Slack->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -218,7 +218,7 @@ class Providers
      *
      * @deprecated use `twitterOAuth1` instead.
      */
-    public static function twitter(string $label = null): string
+    public static function twitter(?string $label = null): string
     {
         return tap(ProviderEnum::Twitter->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -226,7 +226,7 @@ class Providers
     /**
      * Enable the Twitter OAuth 1.0 provider.
      */
-    public static function twitterOAuth1(string $label = null): string
+    public static function twitterOAuth1(?string $label = null): string
     {
         return tap(ProviderEnum::Twitter->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
@@ -234,12 +234,12 @@ class Providers
     /**
      * Enable the Twitter OAuth 2.0 provider.
      */
-    public static function twitterOAuth2(string $label = null): string
+    public static function twitterOAuth2(?string $label = null): string
     {
         return tap(ProviderEnum::TwitterOAuth2->value, fn (string $provider) => static::addLabelFor($provider, $label));
     }
 
-    public static function addLabelFor(ProviderEnum|string $provider, string $label = null): void
+    public static function addLabelFor(ProviderEnum|string $provider, ?string $label = null): void
     {
         if (! $label) {
             return;

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -120,7 +120,7 @@ class Socialstream
     /**
      * Get a completion redirect path for a specific feature.
      */
-    public static function redirects(string $redirect, $default = null)
+    public static function redirects(string $redirect, mixed $default = null)
     {
         return config('socialstream.redirects.'.$redirect) ?? $default ?? config('socialstream.home');
     }

--- a/stubs/breeze/database/factories/UserFactory.php
+++ b/stubs/breeze/database/factories/UserFactory.php
@@ -48,7 +48,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the user should have a connected account for the given provider.
      */
-    public function withConnectedAccount(string $provider, callable $callback = null): static
+    public function withConnectedAccount(string $provider, ?callable $callback = null): static
     {
         if (! Providers::enabled($provider)) {
             return $this->state([]);

--- a/stubs/filament/database/factories/UserFactory.php
+++ b/stubs/filament/database/factories/UserFactory.php
@@ -45,7 +45,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the user should have a connected account for the given provider.
      */
-    public function withConnectedAccount(string $provider, callable $callback = null): static
+    public function withConnectedAccount(string $provider, ?callable $callback = null): static
     {
         if (! Providers::enabled($provider)) {
             return $this->state([]);

--- a/stubs/jetstream/database/factories/UserFactory.php
+++ b/stubs/jetstream/database/factories/UserFactory.php
@@ -48,7 +48,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the user should have a personal team.
      */
-    public function withPersonalTeam(callable $callback = null): static
+    public function withPersonalTeam(?callable $callback = null): static
     {
         if (! JetstreamFeatures::hasTeamFeatures()) {
             return $this->state([]);
@@ -69,7 +69,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the user should have a connected account for the given provider.
      */
-    public function withConnectedAccount(string $provider, callable $callback = null): static
+    public function withConnectedAccount(string $provider, ?callable $callback = null): static
     {
         if (! Providers::enabled($provider)) {
             return $this->state([]);


### PR DESCRIPTION
## Resolve PHP 8.4 notices for deprecated 'Implicitly marking parameters as nullable'

[//]: # (copilot:summary)
Mostly annotating types as nullable by prepending a question mark.

## Explanation  <!-- A more in depth explanation of the approach, reasoning, questions etc... -->

[//]: # (copilot:walkthrough)
[PHP 8.4](https://www.php.net/archive/2024.php) has a core deprecation of [implicitly nullable parameter types](https://github.com/php/php-src/blob/php-8.4.0RC1/UPGRADING#L497). This PR resolves that issue.

## Checklist <!-- Put an `x` in all the boxes that apply. -->

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [x] I've given a good reason as to why this PR exposes new / removes existing user data
