### PR TITLE
[6.x] fix auth when using a custom authentication pipeline in Fortify

### DIFF
--- a/stubs/app/Providers/SocialstreamServiceProvider.php
+++ b/stubs/app/Providers/SocialstreamServiceProvider.php
@@ -11,7 +11,6 @@ use App\Actions\Socialstream\UpdateConnectedAccount;
 use Illuminate\Support\ServiceProvider;
 use JoelButcher\Socialstream\Concerns\ConfirmsFilament;
 use JoelButcher\Socialstream\Socialstream;
-use Laravel\Fortify\Fortify;
 
 class SocialstreamServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Fixes a bug where, when using `Fortify::authenticateThrough` in a service provider, the auth for Socialstream fails and kicks users out of the application (e.g. to the My Account page for Google OAuth).

The problem is fixed by iterating over the pipes used by Fortify (or in the custom callback) and replacing Fortify's instances of `AttemptToAuthenticate` and `RedirectIfTwoFactorAuthenticatable` with our own.

Resolves #378 

> [!Note]
> This does not solve the problem where developers create their own custom authentication implementations and don't use fortify's at all