### PR TITLE
[6.x] retrieve the model to allow deletion to fire model events

### DIFF
--- a/src/Http/Controllers/Inertia/ConnectedAccountController.php
+++ b/src/Http/Controllers/Inertia/ConnectedAccountController.php
@@ -31,6 +31,7 @@ class ConnectedAccountController extends Controller
         Socialstream::connectedAccountModel()::query()
             ->where('id', $id)
             ->where('user_id', $request->user()->id)
+            ->first()
             ->delete();
 
         Session::flash('flash.banner', __('Account removed'));


### PR DESCRIPTION
## Summary

Directly deleting the database entry prevents the deletion model event from firing.

Resolves #382

## Explanation

This pull request retrieves the relevant model prior to issuing the deletion so as to trigger the deletion model event.

## Checklist

- [x] I've read this template
- [x] I've checked reviewed this PR myself, ensuring consistency and quality with the rest of the project
- [x] I've given a good reason as to why this PR exposes new / removes existing user data
