### PR TITLE
[6.x] Allow custom OAuth prompts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "laravel/socialite": "^5.12"
     },
     "require-dev": {
+        "inertiajs/inertia-laravel": "^2.0",
         "laravel/breeze": "^2.3",
         "laravel/jetstream": "^5.0",
         "laravel/sanctum": "^4.0",

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -7,10 +7,10 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
+use Inertia\Response as InertiaResponse;
 use JoelButcher\Socialstream\Contracts\AuthenticatesOAuthCallback;
 use JoelButcher\Socialstream\Contracts\GeneratesProviderRedirect;
 use JoelButcher\Socialstream\Contracts\HandlesInvalidState;
@@ -20,6 +20,7 @@ use JoelButcher\Socialstream\Contracts\SocialstreamResponse;
 use JoelButcher\Socialstream\Events\OAuthProviderLinkFailed;
 use JoelButcher\Socialstream\Http\Responses\OAuthProviderLinkFailedResponse;
 use JoelButcher\Socialstream\Providers;
+use JoelButcher\Socialstream\Socialstream;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Socialite\Two\InvalidStateException;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
@@ -71,8 +72,12 @@ class OAuthController extends Controller
     /**
      * Show the oauth confirmation page.
      */
-    public function prompt(string $provider): View
+    public function prompt(string $provider): View|InertiaResponse
     {
+        if (Socialstream::$oAuthConfirmationPrompt) {
+            return app(Socialstream::$oAuthConfirmationPrompt)($provider);
+        }
+
         return view('socialstream::oauth.prompt', [
             'provider' => $provider,
         ]);

--- a/src/Socialstream.php
+++ b/src/Socialstream.php
@@ -3,7 +3,9 @@
 namespace JoelButcher\Socialstream;
 
 use Closure;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Str;
+use Inertia\Response;
 use JoelButcher\Socialstream\Contracts\AuthenticatesOAuthCallback;
 use JoelButcher\Socialstream\Contracts\CreatesConnectedAccounts;
 use JoelButcher\Socialstream\Contracts\CreatesUserFromProvider;
@@ -53,6 +55,13 @@ class Socialstream
      * @var array<string, Closure|string>
      */
     public static array $refreshTokenResolvers = [];
+
+    /**
+     * The callback that should be used to prompt the user to confirm their OAuth authorization.
+     *
+     * @var ?(Closure(string): (Response|View))
+     */
+    public static ?Closure $oAuthConfirmationPrompt = null;
 
     /**
      * Get the name of the user model used by the application.
@@ -389,5 +398,15 @@ class Socialstream
         }
 
         return (new $callback)->refreshToken($connectedAccount);
+    }
+
+    /**
+     * Register a callback that should be used to prompt the user to confirm their OAuth.
+     *
+     * @param ?(callable(string): (Response|View)) $callback
+     */
+    public static function promptOAuthLinkUsing(?callable $callback): void
+    {
+        self::$oAuthConfirmationPrompt = $callback ? $callback(...) : null;
     }
 }

--- a/stubs/breeze/inertia/app/Http/Controllers/ProfileController.php
+++ b/stubs/breeze/inertia/app/Http/Controllers/ProfileController.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Session;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class ProfileController extends Controller
+class ProfileController
 {
     /**
      * Display the user's profile form.


### PR DESCRIPTION
This PR allows developers to override how a user is prompted to confirm a connection with an OAuth provider when they are logged in.

Simply pass a closure to `Socialstream::promptOAuthLinkUsing(...)` that returns either `view(...)` or `Inertia::render(...)` inside the `boot` method of your `AppServiceProvider`:


### Livewire / Blade
```php
public function boot(): void
{
    Socialstream::promptOAuthLinkUsing(
        fn (string $provider) => view('pages.auth.oauth.confirm-link-provider', ['provider' => $provider])
    );
}
```

### Inertia
```php
public function boot(): void
{
    Socialstream::promptOAuthLinkUsing(
        fn (string $provider) => Inertia::render('Auth/OAuth/ConfirmLinkProvider', ['provider' => $provider])
    );
}
```